### PR TITLE
Enhance reactive generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,63 @@ let Main argv = NXUI.Run(Build, "NXUI", argv)
 >     <LangVersion>preview</LangVersion>
 > </PropertyGroup>
 > ```
+
+## Extensions
+
+NXUI ships with a rich set of extension methods and builder helpers so that all
+UI composition can be expressed in C#.  The code generator produces most of
+these members for every Avalonia control and property.
+
+### Builders
+
+`NXUI.Builders` exposes factory methods for every control type.  Each method
+creates the control instance and overloads let you capture it via `out var` for
+later use.
+
+### Property helpers
+
+For each Avalonia property the following methods are generated:
+
+* **`<Name>(value)`** – set the property value.
+* **`<Name>(IBinding, mode, priority)`** – bind with an Avalonia binding.
+* **`<Name>(IObservable<T>, mode, priority)`** – bind from an observable.
+* **`Bind<Name>(mode, priority)`** – create a binding descriptor.
+* **`Observe<Name>()`** – observable of property values.
+* **`On<Name>(handler)`** – pass the observable to a handler.
+* **`ObserveBinding<Name>()`** – observe binding values including errors.
+* **`OnBinding<Name>(handler)`** – receive the binding observable.
+* **`Observe<Name>Changed()`** – observe full change events.
+* **`On<Name>Changed(handler)`** – handler for change observable.
+
+Enum properties get convenience methods for each enum value, e.g.
+`HorizontalAlignmentCenter()`.
+
+### Event helpers
+
+For routed and CLR events:
+
+* **`ObserveOn<EventName>(routes)`** – returns an `IObservable` sequence.
+* **`On<EventName>(handler, routes)`** – handler receiving the observable.
+* **`On<EventName>Handler(action, routes)`** – attach a simple callback.
+
+### Style setters
+
+`Set<ClassName><PropertyName>` methods on `Style` and `KeyFrame` let you define
+style values using constants, bindings or observables.
+
+### Core runtime helpers
+
+`NXUI.Extensions.AvaloniaObjectExtensions` provides `BindOneWay` and
+`BindTwoWay` to link properties or observables without verbose binding code.
+
+`NXUI.Extensions.ReactiveObservableExtensions` adds utilities for reactive
+workflows:
+
+- `ObserveOnUiThread` / `SubscribeOnUiThread`
+- `TakeUntilDetachedFromVisualTree` / `SubscribeUntilDetached`
+- `DisposeWith`
+- `DataTemplate<T>`
+- `WhenAnyValue` (single or multiple expressions)
+
+Together these extensions enable complex, reactive UIs built entirely in code
+while managing resources with minimal overhead.

--- a/src/Generator/Templates/Templates.Extensions.cs
+++ b/src/Generator/Templates/Templates.Extensions.cs
@@ -133,6 +133,54 @@ public static partial class Templates
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<%ValueType%>> ObserveBinding%Name%(this %OwnerType% obj)
+    {
+        return obj.GetBindingObservable(%ClassType%.%Name%Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBinding%Name%<T>(this T obj, Action<%OwnerType%, IObservable<BindingValue<%ValueType%>>> handler) where T : %OwnerType%
+    {
+        var observable = obj.GetBindingObservable(%ClassType%.%Name%Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> Observe%Name%Changed(this %OwnerType% obj)
+    {
+        return obj.GetPropertyChangedObservable(%ClassType%.%Name%Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T On%Name%Changed<T>(this T obj, Action<%OwnerType%, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : %OwnerType%
+    {
+        var observable = obj.GetPropertyChangedObservable(%ClassType%.%Name%Property);
+        handler(obj, observable);
+        return obj;
+    }
 """;
 
     public static string PropertyMethodsTemplateSealed = """
@@ -228,6 +276,52 @@ public static partial class Templates
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<%ValueType%>> ObserveBinding%Name%(this %OwnerType% obj)
+    {
+        return obj.GetBindingObservable(%ClassType%.%Name%Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static %OwnerType% OnBinding%Name%(this %OwnerType% obj, Action<%OwnerType%, IObservable<BindingValue<%ValueType%>>> handler)
+    {
+        var observable = obj.GetBindingObservable(%ClassType%.%Name%Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> Observe%Name%Changed(this %OwnerType% obj)
+    {
+        return obj.GetPropertyChangedObservable(%ClassType%.%Name%Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static %OwnerType% On%Name%Changed(this %OwnerType% obj, Action<%OwnerType%, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(%ClassType%.%Name%Property);
+        handler(obj, observable);
+        return obj;
+    }
 """;
 
     public static string PropertyMethodsTemplateReadOnly = """
@@ -271,6 +365,52 @@ public static partial class Templates
     public static %OwnerType% On%Name%(this %OwnerType% obj, Action<%OwnerType%, IObservable<%ValueType%>> handler)
     {
         var observable = obj.GetObservable(%ClassType%.%Name%Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<%ValueType%>> ObserveBinding%Name%(this %OwnerType% obj)
+    {
+        return obj.GetBindingObservable(%ClassType%.%Name%Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static %OwnerType% OnBinding%Name%(this %OwnerType% obj, Action<%OwnerType%, IObservable<BindingValue<%ValueType%>>> handler)
+    {
+        var observable = obj.GetBindingObservable(%ClassType%.%Name%Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> Observe%Name%Changed(this %OwnerType% obj)
+    {
+        return obj.GetPropertyChangedObservable(%ClassType%.%Name%Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="%ClassType%.%Name%Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static %OwnerType% On%Name%Changed(this %OwnerType% obj, Action<%OwnerType%, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(%ClassType%.%Name%Property);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Extensions/ReactiveObservableExtensions.cs
+++ b/src/NXUI/Extensions/ReactiveObservableExtensions.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq.Expressions;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Animators;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Threading;
+using System.Reflection;
+
+namespace NXUI.Extensions;
+
+public static class ReactiveObservableExtensions
+{
+    public static IObservable<T> ObserveOnUiThread<T>(this IObservable<T> source)
+    {
+        return Observable.Create<T>(observer =>
+            source.Subscribe(
+                x => Avalonia.Threading.Dispatcher.UIThread.Post(() => observer.OnNext(x)),
+                ex => Avalonia.Threading.Dispatcher.UIThread.Post(() => observer.OnError(ex)),
+                () => Avalonia.Threading.Dispatcher.UIThread.Post(observer.OnCompleted)));
+    }
+
+    public static IDisposable SubscribeOnUiThread<T>(this IObservable<T> source, Action<T> onNext)
+    {
+        return source.ObserveOnUiThread().Subscribe(onNext);
+    }
+
+    public static IObservable<T> TakeUntilDetachedFromVisualTree<T>(this IObservable<T> source, Visual visual)
+    {
+        return source.TakeUntil(visual.OnDetachedFromVisualTree());
+    }
+
+    public static IDisposable SubscribeUntilDetached<T>(this IObservable<T> source, Visual visual, Action<T> onNext)
+    {
+        return source
+            .TakeUntilDetachedFromVisualTree(visual)
+            .Subscribe(onNext);
+    }
+
+    public static IDisposable DisposeWith(this IDisposable disposable, CompositeDisposable composite)
+    {
+        composite.Add(disposable);
+        return disposable;
+    }
+
+    public static FuncDataTemplate<T> DataTemplate<T>(Func<T, Control?> build, bool supportsRecycling = false) where T : class
+    {
+        return new FuncDataTemplate<T>((item, _) => build(item), supportsRecycling);
+    }
+
+
+    public static IObservable<TResult> WhenAnyValue<T, TResult>(this T source,
+        Expression<Func<T, TResult>> selector) where T : AvaloniaObject
+    {
+        var field = typeof(T).GetField(selector.GetMemberName() + "Property", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+        var prop = (AvaloniaProperty<TResult>)field!.GetValue(null)!;
+        return source.GetObservable(prop);
+    }
+
+    public static IObservable<(T1, T2)> WhenAnyValue<T, T1, T2>(this T source,
+        Expression<Func<T, T1>> selector1, Expression<Func<T, T2>> selector2) where T : AvaloniaObject
+    {
+        return Observable.CombineLatest(
+            source.WhenAnyValue(selector1),
+            source.WhenAnyValue(selector2),
+            (v1, v2) => (v1, v2));
+    }
+}
+
+internal static class ExpressionExtensions
+{
+    public static string GetMemberName(this LambdaExpression expression)
+    {
+        if (expression.Body is MemberExpression member)
+            return member.Member.Name;
+        throw new ArgumentException("Invalid expression", nameof(expression));
+    }
+}

--- a/src/NXUI/Generated/Extensions/AccessText.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/AccessText.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class AccessTextExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowAccessKey(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowAccessKey<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowAccessKeyChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowAccessKeyChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AccessText.ShowAccessKeyProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/AdornerLayer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/AdornerLayer.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class AdornerLayerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Visual>> ObserveBindingAdornedElement(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAdornedElement<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Visual>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAdornedElementChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAdornedElementChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornedElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class AdornerLayerExtensions
     public static T OnIsClipEnabled<T>(this T obj, Action<Avalonia.Visual, IObservable<System.Boolean>> handler) where T : Avalonia.Visual
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsClipEnabled(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsClipEnabled<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsClipEnabledChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsClipEnabledChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.IsClipEnabledProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class AdornerLayerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingAdorner(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAdorner<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAdornerChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAdornerChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.AdornerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class AdornerLayerExtensions
     public static T OnDefaultFocusAdorner<T>(this T obj, Action<Avalonia.Controls.Primitives.AdornerLayer, IObservable<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.Primitives.AdornerLayer
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> ObserveBindingDefaultFocusAdorner(this Avalonia.Controls.Primitives.AdornerLayer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDefaultFocusAdorner<T>(this T obj, Action<Avalonia.Controls.Primitives.AdornerLayer, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>>> handler) where T : Avalonia.Controls.Primitives.AdornerLayer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDefaultFocusAdornerChanged(this Avalonia.Controls.Primitives.AdornerLayer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDefaultFocusAdornerChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.AdornerLayer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.AdornerLayer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.AdornerLayer.DefaultFocusAdornerProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Animatable.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Animatable.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class AnimatableExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animatable.TransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.Transitions>> ObserveBindingTransitions(this Avalonia.Animation.Animatable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animatable.TransitionsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animatable.TransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransitions<T>(this T obj, Action<Avalonia.Animation.Animatable, IObservable<BindingValue<Avalonia.Animation.Transitions>>> handler) where T : Avalonia.Animation.Animatable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animatable.TransitionsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animatable.TransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransitionsChanged(this Avalonia.Animation.Animatable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animatable.TransitionsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animatable.TransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransitionsChanged<T>(this T obj, Action<Avalonia.Animation.Animatable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Animation.Animatable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animatable.TransitionsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Animation.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Animation.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class AnimationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingDuration(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.DurationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingDuration(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<System.TimeSpan>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.DurationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDurationChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.DurationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnDurationChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.DurationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Animation.Animation.IterationCountProperty
 
     /// <summary>
@@ -192,6 +238,52 @@ public static partial class AnimationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.IterationCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.IterationCount>> ObserveBindingIterationCount(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.IterationCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.IterationCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingIterationCount(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<Avalonia.Animation.IterationCount>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.IterationCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.IterationCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIterationCountChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.IterationCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.IterationCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnIterationCountChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.IterationCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Animation.Animation.PlaybackDirectionProperty
 
     /// <summary>
@@ -281,6 +373,52 @@ public static partial class AnimationExtensions
     public static Avalonia.Animation.Animation OnPlaybackDirection(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<Avalonia.Animation.PlaybackDirection>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Animation.Animation.PlaybackDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.PlaybackDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.PlaybackDirection>> ObserveBindingPlaybackDirection(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.PlaybackDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.PlaybackDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingPlaybackDirection(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<Avalonia.Animation.PlaybackDirection>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.PlaybackDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.PlaybackDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlaybackDirectionChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.PlaybackDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.PlaybackDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnPlaybackDirectionChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.PlaybackDirectionProperty);
         handler(obj, observable);
         return obj;
     }
@@ -423,6 +561,52 @@ public static partial class AnimationExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.FillModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.FillMode>> ObserveBindingFillMode(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.FillModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.FillModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingFillMode(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<Avalonia.Animation.FillMode>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.FillModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.FillModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFillModeChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.FillModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.FillModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnFillModeChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.FillModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Animation.Animation.FillModeProperty"/> property value to <see cref="Avalonia.Animation.FillMode.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -559,6 +743,52 @@ public static partial class AnimationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.Easings.Easing>> ObserveBindingEasing(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.EasingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingEasing(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<Avalonia.Animation.Easings.Easing>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.EasingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEasingChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.EasingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnEasingChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.EasingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Animation.Animation.DelayProperty
 
     /// <summary>
@@ -648,6 +878,52 @@ public static partial class AnimationExtensions
     public static Avalonia.Animation.Animation OnDelay(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<System.TimeSpan>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Animation.Animation.DelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingDelay(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.DelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingDelay(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<System.TimeSpan>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.DelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDelayChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.DelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnDelayChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.DelayProperty);
         handler(obj, observable);
         return obj;
     }
@@ -745,6 +1021,52 @@ public static partial class AnimationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.DelayBetweenIterationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingDelayBetweenIterations(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.DelayBetweenIterationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.DelayBetweenIterationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingDelayBetweenIterations(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<System.TimeSpan>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.DelayBetweenIterationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.DelayBetweenIterationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDelayBetweenIterationsChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.DelayBetweenIterationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.DelayBetweenIterationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnDelayBetweenIterationsChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.DelayBetweenIterationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Animation.Animation.SpeedRatioProperty
 
     /// <summary>
@@ -834,6 +1156,52 @@ public static partial class AnimationExtensions
     public static Avalonia.Animation.Animation OnSpeedRatio(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Animation.Animation.SpeedRatioProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.Animation.SpeedRatioProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSpeedRatio(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.Animation.SpeedRatioProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.Animation.SpeedRatioProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnBindingSpeedRatio(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.Animation.SpeedRatioProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.Animation.SpeedRatioProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSpeedRatioChanged(this Avalonia.Animation.Animation obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.SpeedRatioProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.Animation.SpeedRatioProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Animation.Animation OnSpeedRatioChanged(this Avalonia.Animation.Animation obj, Action<Avalonia.Animation.Animation, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.Animation.SpeedRatioProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Application.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Application.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ApplicationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Application.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingDataContext(this Avalonia.Application obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Application.DataContextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Application.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDataContext<T>(this T obj, Action<Avalonia.Application, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Application.DataContextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Application.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDataContextChanged(this Avalonia.Application obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Application.DataContextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Application.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDataContextChanged<T>(this T obj, Action<Avalonia.Application, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Application.DataContextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Application.ActualThemeVariantProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ApplicationExtensions
     public static T OnActualThemeVariant<T>(this T obj, Action<Avalonia.Application, IObservable<Avalonia.Styling.ThemeVariant>> handler) where T : Avalonia.Application
     {
         var observable = obj.GetObservable(Avalonia.Application.ActualThemeVariantProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Application.ActualThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ThemeVariant>> ObserveBindingActualThemeVariant(this Avalonia.Application obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Application.ActualThemeVariantProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Application.ActualThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingActualThemeVariant<T>(this T obj, Action<Avalonia.Application, IObservable<BindingValue<Avalonia.Styling.ThemeVariant>>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Application.ActualThemeVariantProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Application.ActualThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveActualThemeVariantChanged(this Avalonia.Application obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Application.ActualThemeVariantProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Application.ActualThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnActualThemeVariantChanged<T>(this T obj, Action<Avalonia.Application, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Application.ActualThemeVariantProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class ApplicationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Application.RequestedThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ThemeVariant>> ObserveBindingRequestedThemeVariant(this Avalonia.Application obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Application.RequestedThemeVariantProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Application.RequestedThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRequestedThemeVariant<T>(this T obj, Action<Avalonia.Application, IObservable<BindingValue<Avalonia.Styling.ThemeVariant>>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Application.RequestedThemeVariantProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Application.RequestedThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRequestedThemeVariantChanged(this Avalonia.Application obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Application.RequestedThemeVariantProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Application.RequestedThemeVariantProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRequestedThemeVariantChanged<T>(this T obj, Action<Avalonia.Application, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Application.RequestedThemeVariantProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Application.NameProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class ApplicationExtensions
     public static T OnName<T>(this T obj, Action<Avalonia.Application, IObservable<System.String>> handler) where T : Avalonia.Application
     {
         var observable = obj.GetObservable(Avalonia.Application.NameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Application.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingName(this Avalonia.Application obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Application.NameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Application.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingName<T>(this T obj, Action<Avalonia.Application, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Application.NameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Application.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveNameChanged(this Avalonia.Application obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Application.NameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Application.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnNameChanged<T>(this T obj, Action<Avalonia.Application, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Application.NameProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Arc.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Arc.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ArcExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Arc.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStartAngle(this Avalonia.Controls.Shapes.Arc obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Arc.StartAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Arc.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStartAngle<T>(this T obj, Action<Avalonia.Controls.Shapes.Arc, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Arc
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Arc.StartAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Arc.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStartAngleChanged(this Avalonia.Controls.Shapes.Arc obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Arc.StartAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Arc.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStartAngleChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Arc, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Arc
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Arc.StartAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Arc.SweepAngleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ArcExtensions
     public static T OnSweepAngle<T>(this T obj, Action<Avalonia.Controls.Shapes.Arc, IObservable<System.Double>> handler) where T : Avalonia.Controls.Shapes.Arc
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Arc.SweepAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Arc.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSweepAngle(this Avalonia.Controls.Shapes.Arc obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Arc.SweepAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Arc.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSweepAngle<T>(this T obj, Action<Avalonia.Controls.Shapes.Arc, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Arc
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Arc.SweepAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Arc.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSweepAngleChanged(this Avalonia.Controls.Shapes.Arc obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Arc.SweepAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Arc.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSweepAngleChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Arc, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Arc
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Arc.SweepAngleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ArcSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ArcSegment.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class ArcSegmentExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ArcSegment.IsLargeArcProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsLargeArc(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ArcSegment.IsLargeArcProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ArcSegment.IsLargeArcProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnBindingIsLargeArc(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ArcSegment.IsLargeArcProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ArcSegment.IsLargeArcProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsLargeArcChanged(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.IsLargeArcProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ArcSegment.IsLargeArcProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnIsLargeArcChanged(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.IsLargeArcProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ArcSegment.PointProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class ArcSegmentExtensions
     public static Avalonia.Media.ArcSegment OnPoint(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<Avalonia.Point>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.ArcSegment.PointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ArcSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ArcSegment.PointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ArcSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnBindingPoint(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ArcSegment.PointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ArcSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointChanged(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.PointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ArcSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnPointChanged(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.PointProperty);
         handler(obj, observable);
         return obj;
     }
@@ -285,6 +377,52 @@ public static partial class ArcSegmentExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ArcSegment.RotationAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRotationAngle(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ArcSegment.RotationAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ArcSegment.RotationAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnBindingRotationAngle(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ArcSegment.RotationAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ArcSegment.RotationAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRotationAngleChanged(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.RotationAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ArcSegment.RotationAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnRotationAngleChanged(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.RotationAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ArcSegment.SizeProperty
 
     /// <summary>
@@ -378,6 +516,52 @@ public static partial class ArcSegmentExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ArcSegment.SizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingSize(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ArcSegment.SizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ArcSegment.SizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnBindingSize(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ArcSegment.SizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ArcSegment.SizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSizeChanged(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.SizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ArcSegment.SizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnSizeChanged(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.SizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ArcSegment.SweepDirectionProperty
 
     /// <summary>
@@ -467,6 +651,52 @@ public static partial class ArcSegmentExtensions
     public static Avalonia.Media.ArcSegment OnSweepDirection(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<Avalonia.Media.SweepDirection>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.ArcSegment.SweepDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ArcSegment.SweepDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.SweepDirection>> ObserveBindingSweepDirection(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ArcSegment.SweepDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ArcSegment.SweepDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnBindingSweepDirection(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<BindingValue<Avalonia.Media.SweepDirection>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ArcSegment.SweepDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ArcSegment.SweepDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSweepDirectionChanged(this Avalonia.Media.ArcSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.SweepDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ArcSegment.SweepDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ArcSegment OnSweepDirectionChanged(this Avalonia.Media.ArcSegment obj, Action<Avalonia.Media.ArcSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ArcSegment.SweepDirectionProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/AutoCompleteBox.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/AutoCompleteBox.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingCaretIndex(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.CaretIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretIndex<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.CaretIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretIndexChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.CaretIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretIndexChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.CaretIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.WatermarkProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnWatermark<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.String>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingWatermark(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWatermark<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWatermarkChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWatermarkChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.WatermarkProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinimumPrefixLength(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinimumPrefixLength<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinimumPrefixLengthChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinimumPrefixLengthChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MinimumPrefixLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnMinimumPopulateDelay<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.TimeSpan>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingMinimumPopulateDelay(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinimumPopulateDelay<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinimumPopulateDelayChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinimumPopulateDelayChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MinimumPopulateDelayProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxDropDownHeight(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxDropDownHeight<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxDropDownHeightChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxDropDownHeightChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MaxDropDownHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnIsTextCompletionEnabled<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsTextCompletionEnabled(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsTextCompletionEnabled<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsTextCompletionEnabledChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsTextCompletionEnabledChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.IsTextCompletionEnabledProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingItemTemplate(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemTemplate<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemTemplateChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemTemplateChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnIsDropDownOpen<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDropDownOpen(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDropDownOpen<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDropDownOpenChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDropDownOpenChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.IsDropDownOpenProperty);
         handler(obj, observable);
         return obj;
     }
@@ -888,6 +1272,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectedItem(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedItem<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedItemChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedItemChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.TextProperty
 
     /// <summary>
@@ -986,6 +1418,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.SearchTextProperty
 
     /// <summary>
@@ -1026,6 +1506,52 @@ public static partial class AutoCompleteBoxExtensions
     public static Avalonia.Controls.AutoCompleteBox OnSearchText(this Avalonia.Controls.AutoCompleteBox obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.String>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.SearchTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.SearchTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingSearchText(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.SearchTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.SearchTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.AutoCompleteBox OnBindingSearchText(this Avalonia.Controls.AutoCompleteBox obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.String>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.SearchTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.SearchTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSearchTextChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.SearchTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.SearchTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.AutoCompleteBox OnSearchTextChanged(this Avalonia.Controls.AutoCompleteBox obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.SearchTextProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1124,6 +1650,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnFilterMode<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<Avalonia.Controls.AutoCompleteFilterMode>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.FilterModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.FilterModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.AutoCompleteFilterMode>> ObserveBindingFilterMode(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.FilterModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.FilterModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFilterMode<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<Avalonia.Controls.AutoCompleteFilterMode>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.FilterModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.FilterModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFilterModeChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.FilterModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.FilterModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFilterModeChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.FilterModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1394,6 +1968,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.AutoCompleteFilterPredicate<System.Object>>> ObserveBindingItemFilter(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemFilterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemFilter<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<Avalonia.Controls.AutoCompleteFilterPredicate<System.Object>>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemFilterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemFilterChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemFilterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemFilterChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemFilterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.TextFilterProperty
 
     /// <summary>
@@ -1488,6 +2110,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnTextFilter<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<Avalonia.Controls.AutoCompleteFilterPredicate<System.String>>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.TextFilterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.AutoCompleteFilterPredicate<System.String>>> ObserveBindingTextFilter(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.TextFilterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextFilter<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<Avalonia.Controls.AutoCompleteFilterPredicate<System.String>>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.TextFilterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextFilterChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.TextFilterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextFilterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextFilterChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.TextFilterProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1590,6 +2260,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.AutoCompleteSelector<System.Object>>> ObserveBindingItemSelector(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemSelector<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<Avalonia.Controls.AutoCompleteSelector<System.Object>>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemSelectorChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemSelectorChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemSelectorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.TextSelectorProperty
 
     /// <summary>
@@ -1684,6 +2402,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnTextSelector<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<Avalonia.Controls.AutoCompleteSelector<System.String>>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.TextSelectorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.AutoCompleteSelector<System.String>>> ObserveBindingTextSelector(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.TextSelectorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextSelector<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<Avalonia.Controls.AutoCompleteSelector<System.String>>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.TextSelectorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextSelectorChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.TextSelectorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.TextSelectorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextSelectorChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.TextSelectorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1786,6 +2552,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.IEnumerable>> ObserveBindingItemsSource(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsSource<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Collections.IEnumerable>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsSourceChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsSourceChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty
 
     /// <summary>
@@ -1880,6 +2694,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnAsyncPopulator<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.Func<System.String,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Object>>>>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Func<System.String,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Object>>>>> ObserveBindingAsyncPopulator(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAsyncPopulator<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Func<System.String,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Object>>>>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAsyncPopulatorChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAsyncPopulatorChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.AsyncPopulatorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1982,6 +2844,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxLength(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MaxLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxLength<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.MaxLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxLengthChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MaxLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxLengthChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.MaxLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty
 
     /// <summary>
@@ -2080,6 +2990,54 @@ public static partial class AutoCompleteBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingInnerLeftContent(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInnerLeftContent<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInnerLeftContentChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInnerLeftContentChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.InnerLeftContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty
 
     /// <summary>
@@ -2174,6 +3132,54 @@ public static partial class AutoCompleteBoxExtensions
     public static T OnInnerRightContent<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<System.Object>> handler) where T : Avalonia.Controls.AutoCompleteBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingInnerRightContent(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInnerRightContent<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInnerRightContentChanged(this Avalonia.Controls.AutoCompleteBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInnerRightContentChanged<T>(this T obj, Action<Avalonia.Controls.AutoCompleteBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.AutoCompleteBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.AutoCompleteBox.InnerRightContentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/BezierSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/BezierSegment.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class BezierSegmentExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.BezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint1(this Avalonia.Media.BezierSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.BezierSegment.Point1Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.BezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BezierSegment OnBindingPoint1(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.BezierSegment.Point1Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.BezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePoint1Changed(this Avalonia.Media.BezierSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.BezierSegment.Point1Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.BezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BezierSegment OnPoint1Changed(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.BezierSegment.Point1Property);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.BezierSegment.Point2Property
 
     /// <summary>
@@ -192,6 +238,52 @@ public static partial class BezierSegmentExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.BezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint2(this Avalonia.Media.BezierSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.BezierSegment.Point2Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.BezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BezierSegment OnBindingPoint2(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.BezierSegment.Point2Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.BezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePoint2Changed(this Avalonia.Media.BezierSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.BezierSegment.Point2Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.BezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BezierSegment OnPoint2Changed(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.BezierSegment.Point2Property);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.BezierSegment.Point3Property
 
     /// <summary>
@@ -281,6 +373,52 @@ public static partial class BezierSegmentExtensions
     public static Avalonia.Media.BezierSegment OnPoint3(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<Avalonia.Point>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.BezierSegment.Point3Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.BezierSegment.Point3Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint3(this Avalonia.Media.BezierSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.BezierSegment.Point3Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.BezierSegment.Point3Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BezierSegment OnBindingPoint3(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.BezierSegment.Point3Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.BezierSegment.Point3Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePoint3Changed(this Avalonia.Media.BezierSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.BezierSegment.Point3Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.BezierSegment.Point3Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BezierSegment OnPoint3Changed(this Avalonia.Media.BezierSegment obj, Action<Avalonia.Media.BezierSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.BezierSegment.Point3Property);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/BlurEffect.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/BlurEffect.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class BlurEffectExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.BlurEffect.RadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadius(this Avalonia.Media.BlurEffect obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.BlurEffect.RadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.BlurEffect.RadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BlurEffect OnBindingRadius(this Avalonia.Media.BlurEffect obj, Action<Avalonia.Media.BlurEffect, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.BlurEffect.RadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.BlurEffect.RadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusChanged(this Avalonia.Media.BlurEffect obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.BlurEffect.RadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.BlurEffect.RadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.BlurEffect OnRadiusChanged(this Avalonia.Media.BlurEffect obj, Action<Avalonia.Media.BlurEffect, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.BlurEffect.RadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Border.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Border.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class BorderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Border.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Border.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Border.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Border.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Border.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Border.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Border.BackgroundSizingProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class BorderExtensions
     public static T OnBackgroundSizing<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<Avalonia.Media.BackgroundSizing>> handler) where T : Avalonia.Controls.Border
     {
         var observable = obj.GetObservable(Avalonia.Controls.Border.BackgroundSizingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Border.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.BackgroundSizing>> ObserveBindingBackgroundSizing(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Border.BackgroundSizingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Border.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackgroundSizing<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<BindingValue<Avalonia.Media.BackgroundSizing>>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Border.BackgroundSizingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Border.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundSizingChanged(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BackgroundSizingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Border.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundSizingChanged<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BackgroundSizingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -336,6 +432,54 @@ public static partial class BorderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Border.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBorderBrush(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Border.BorderBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Border.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBorderBrush<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Border.BorderBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Border.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBorderBrushChanged(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BorderBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Border.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBorderBrushChanged<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BorderBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Border.BorderThicknessProperty
 
     /// <summary>
@@ -430,6 +574,54 @@ public static partial class BorderExtensions
     public static T OnBorderThickness<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<Avalonia.Thickness>> handler) where T : Avalonia.Controls.Border
     {
         var observable = obj.GetObservable(Avalonia.Controls.Border.BorderThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Border.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingBorderThickness(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Border.BorderThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Border.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBorderThickness<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Border.BorderThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Border.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBorderThicknessChanged(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BorderThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Border.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBorderThicknessChanged<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BorderThicknessProperty);
         handler(obj, observable);
         return obj;
     }
@@ -532,6 +724,54 @@ public static partial class BorderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Border.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.CornerRadius>> ObserveBindingCornerRadius(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Border.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Border.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCornerRadius<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<BindingValue<Avalonia.CornerRadius>>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Border.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Border.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCornerRadiusChanged(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Border.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Border.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCornerRadiusChanged<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Border.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Border.BoxShadowProperty
 
     /// <summary>
@@ -626,6 +866,54 @@ public static partial class BorderExtensions
     public static T OnBoxShadow<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<Avalonia.Media.BoxShadows>> handler) where T : Avalonia.Controls.Border
     {
         var observable = obj.GetObservable(Avalonia.Controls.Border.BoxShadowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Border.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.BoxShadows>> ObserveBindingBoxShadow(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Border.BoxShadowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Border.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBoxShadow<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<BindingValue<Avalonia.Media.BoxShadows>>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Border.BoxShadowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Border.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBoxShadowChanged(this Avalonia.Controls.Border obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BoxShadowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Border.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBoxShadowChanged<T>(this T obj, Action<Avalonia.Controls.Border, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Border
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Border.BoxShadowProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Brush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Brush.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class BrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Brush.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOpacity(this Avalonia.Media.Brush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Brush.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Brush.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOpacity<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.Brush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Brush.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Brush.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpacityChanged(this Avalonia.Media.Brush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Brush.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Brush.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOpacityChanged<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.Brush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Brush.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Brush.TransformProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class BrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Brush.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.ITransform>> ObserveBindingTransform(this Avalonia.Media.Brush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Brush.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Brush.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransform<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<BindingValue<Avalonia.Media.ITransform>>> handler) where T : Avalonia.Media.Brush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Brush.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Brush.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransformChanged(this Avalonia.Media.Brush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Brush.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Brush.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransformChanged<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.Brush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Brush.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Brush.TransformOriginProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class BrushExtensions
     public static T OnTransformOrigin<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<Avalonia.RelativePoint>> handler) where T : Avalonia.Media.Brush
     {
         var observable = obj.GetObservable(Avalonia.Media.Brush.TransformOriginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Brush.TransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingTransformOrigin(this Avalonia.Media.Brush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Brush.TransformOriginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Brush.TransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransformOrigin<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<BindingValue<Avalonia.RelativePoint>>> handler) where T : Avalonia.Media.Brush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Brush.TransformOriginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Brush.TransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransformOriginChanged(this Avalonia.Media.Brush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Brush.TransformOriginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Brush.TransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransformOriginChanged<T>(this T obj, Action<Avalonia.Media.Brush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.Brush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Brush.TransformOriginProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Button.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Button.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class ButtonExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.ClickModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ClickMode>> ObserveBindingClickMode(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.ClickModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.ClickModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClickMode<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<Avalonia.Controls.ClickMode>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.ClickModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.ClickModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClickModeChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.ClickModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.ClickModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClickModeChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.ClickModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Button.ClickModeProperty"/> property value to <see cref="Avalonia.Controls.ClickMode.Release"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -226,6 +274,54 @@ public static partial class ButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Windows.Input.ICommand>> ObserveBindingCommand(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommand<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<System.Windows.Input.ICommand>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Button.CommandParameterProperty
 
     /// <summary>
@@ -320,6 +416,54 @@ public static partial class ButtonExtensions
     public static T OnCommandParameter<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<System.Object>> handler) where T : Avalonia.Controls.Button
     {
         var observable = obj.GetObservable(Avalonia.Controls.Button.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingCommandParameter(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommandParameter<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandParameterChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandParameterChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.CommandParameterProperty);
         handler(obj, observable);
         return obj;
     }
@@ -422,6 +566,54 @@ public static partial class ButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.IsDefaultProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDefault(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.IsDefaultProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.IsDefaultProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDefault<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.IsDefaultProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.IsDefaultProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDefaultChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.IsDefaultProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.IsDefaultProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDefaultChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.IsDefaultProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Button.IsCancelProperty
 
     /// <summary>
@@ -520,6 +712,54 @@ public static partial class ButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.IsCancelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsCancel(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.IsCancelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.IsCancelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsCancel<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.IsCancelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.IsCancelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsCancelChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.IsCancelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.IsCancelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsCancelChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.IsCancelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Button.IsPressedProperty
 
     /// <summary>
@@ -560,6 +800,52 @@ public static partial class ButtonExtensions
     public static Avalonia.Controls.Button OnIsPressed(this Avalonia.Controls.Button obj, Action<Avalonia.Controls.Button, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Button.IsPressedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.IsPressedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsPressed(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.IsPressedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.IsPressedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Button OnBindingIsPressed(this Avalonia.Controls.Button obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.IsPressedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.IsPressedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsPressedChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.IsPressedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.IsPressedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Button OnIsPressedChanged(this Avalonia.Controls.Button obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.IsPressedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -658,6 +944,54 @@ public static partial class ButtonExtensions
     public static T OnFlyout<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<Avalonia.Controls.Primitives.FlyoutBase>> handler) where T : Avalonia.Controls.Button
     {
         var observable = obj.GetObservable(Avalonia.Controls.Button.FlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Button.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>> ObserveBindingFlyout(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Button.FlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Button.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFlyout<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Button.FlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Button.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFlyoutChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Button.FlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Button.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFlyoutChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Button.FlyoutProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ButtonSpinner.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ButtonSpinner.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ButtonSpinnerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ButtonSpinner.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAllowSpin(this Avalonia.Controls.ButtonSpinner obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ButtonSpinner.AllowSpinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ButtonSpinner.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAllowSpin<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ButtonSpinner
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ButtonSpinner.AllowSpinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ButtonSpinner.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAllowSpinChanged(this Avalonia.Controls.ButtonSpinner obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ButtonSpinner.AllowSpinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ButtonSpinner.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAllowSpinChanged<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ButtonSpinner
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ButtonSpinner.AllowSpinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ButtonSpinnerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowButtonSpinner(this Avalonia.Controls.ButtonSpinner obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowButtonSpinner<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ButtonSpinner
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowButtonSpinnerChanged(this Avalonia.Controls.ButtonSpinner obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowButtonSpinnerChanged<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ButtonSpinner
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ButtonSpinner.ShowButtonSpinnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ButtonSpinnerExtensions
     public static T OnButtonSpinnerLocation<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<Avalonia.Controls.Location>> handler) where T : Avalonia.Controls.ButtonSpinner
     {
         var observable = obj.GetObservable(Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Location>> ObserveBindingButtonSpinnerLocation(this Avalonia.Controls.ButtonSpinner obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingButtonSpinnerLocation<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<BindingValue<Avalonia.Controls.Location>>> handler) where T : Avalonia.Controls.ButtonSpinner
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveButtonSpinnerLocationChanged(this Avalonia.Controls.ButtonSpinner obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnButtonSpinnerLocationChanged<T>(this T obj, Action<Avalonia.Controls.ButtonSpinner, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ButtonSpinner
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ButtonSpinner.ButtonSpinnerLocationProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Calendar.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Calendar.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class CalendarExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DayOfWeek>> ObserveBindingFirstDayOfWeek(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.FirstDayOfWeekProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFirstDayOfWeek<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<System.DayOfWeek>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.FirstDayOfWeekProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFirstDayOfWeekChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.FirstDayOfWeekProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFirstDayOfWeekChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.FirstDayOfWeekProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Calendar.FirstDayOfWeekProperty"/> property value to <see cref="System.DayOfWeek.Sunday"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -286,6 +334,54 @@ public static partial class CalendarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsTodayHighlighted(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.IsTodayHighlightedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsTodayHighlighted<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.IsTodayHighlightedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsTodayHighlightedChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.IsTodayHighlightedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsTodayHighlightedChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.IsTodayHighlightedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Calendar.HeaderBackgroundProperty
 
     /// <summary>
@@ -384,6 +480,54 @@ public static partial class CalendarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingHeaderBackground(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.HeaderBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeaderBackground<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.HeaderBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderBackgroundChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.HeaderBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.HeaderBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Calendar.DisplayModeProperty
 
     /// <summary>
@@ -478,6 +622,54 @@ public static partial class CalendarExtensions
     public static T OnDisplayMode<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<Avalonia.Controls.CalendarMode>> handler) where T : Avalonia.Controls.Calendar
     {
         var observable = obj.GetObservable(Avalonia.Controls.Calendar.DisplayModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.CalendarMode>> ObserveBindingDisplayMode(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayMode<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<Avalonia.Controls.CalendarMode>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayModeChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayModeChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -612,6 +804,54 @@ public static partial class CalendarExtensions
     public static T OnSelectionMode<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<Avalonia.Controls.CalendarSelectionMode>> handler) where T : Avalonia.Controls.Calendar
     {
         var observable = obj.GetObservable(Avalonia.Controls.Calendar.SelectionModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.CalendarSelectionMode>> ObserveBindingSelectionMode(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.SelectionModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionMode<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<Avalonia.Controls.CalendarSelectionMode>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.SelectionModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionModeChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.SelectionModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionModeChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.SelectionModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -762,6 +1002,54 @@ public static partial class CalendarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTime>>> ObserveBindingSelectedDate(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.SelectedDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedDate<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<System.Nullable<System.DateTime>>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.SelectedDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedDateChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.SelectedDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedDateChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.SelectedDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Calendar.DisplayDateProperty
 
     /// <summary>
@@ -856,6 +1144,54 @@ public static partial class CalendarExtensions
     public static T OnDisplayDate<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<System.DateTime>> handler) where T : Avalonia.Controls.Calendar
     {
         var observable = obj.GetObservable(Avalonia.Controls.Calendar.DisplayDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTime>> ObserveBindingDisplayDate(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayDate<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<System.DateTime>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayDateChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayDateChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayDateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -958,6 +1294,54 @@ public static partial class CalendarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTime>>> ObserveBindingDisplayDateStart(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayDateStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayDateStart<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<System.Nullable<System.DateTime>>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayDateStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayDateStartChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayDateStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayDateStartChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayDateStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Calendar.DisplayDateEndProperty
 
     /// <summary>
@@ -1052,6 +1436,54 @@ public static partial class CalendarExtensions
     public static T OnDisplayDateEnd<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<System.Nullable<System.DateTime>>> handler) where T : Avalonia.Controls.Calendar
     {
         var observable = obj.GetObservable(Avalonia.Controls.Calendar.DisplayDateEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTime>>> ObserveBindingDisplayDateEnd(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayDateEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Calendar.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayDateEnd<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<BindingValue<System.Nullable<System.DateTime>>>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Calendar.DisplayDateEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Calendar.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayDateEndChanged(this Avalonia.Controls.Calendar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayDateEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Calendar.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayDateEndChanged<T>(this T obj, Action<Avalonia.Controls.Calendar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Calendar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Calendar.DisplayDateEndProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/CalendarDatePicker.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/CalendarDatePicker.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTime>> ObserveBindingDisplayDate(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayDate<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.DateTime>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayDateChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayDateChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnDisplayDateStart<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<System.Nullable<System.DateTime>>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTime>>> ObserveBindingDisplayDateStart(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayDateStart<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.Nullable<System.DateTime>>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayDateStartChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayDateStartChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateStartProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTime>>> ObserveBindingDisplayDateEnd(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayDateEnd<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.Nullable<System.DateTime>>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayDateEndChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayDateEndChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.DisplayDateEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnFirstDayOfWeek<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<System.DayOfWeek>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DayOfWeek>> ObserveBindingFirstDayOfWeek(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFirstDayOfWeek<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.DayOfWeek>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFirstDayOfWeekChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFirstDayOfWeekChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.FirstDayOfWeekProperty);
         handler(obj, observable);
         return obj;
     }
@@ -580,6 +772,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDropDownOpen(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDropDownOpen<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDropDownOpenChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDropDownOpenChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.IsDropDownOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty
 
     /// <summary>
@@ -674,6 +914,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnIsTodayHighlighted<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsTodayHighlighted(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsTodayHighlighted<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsTodayHighlightedChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsTodayHighlightedChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.IsTodayHighlightedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -776,6 +1064,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTime>>> ObserveBindingSelectedDate(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedDate<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.Nullable<System.DateTime>>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedDateChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedDateChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty
 
     /// <summary>
@@ -870,6 +1206,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnSelectedDateFormat<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<Avalonia.Controls.CalendarDatePickerFormat>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.CalendarDatePickerFormat>> ObserveBindingSelectedDateFormat(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedDateFormat<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<Avalonia.Controls.CalendarDatePickerFormat>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedDateFormatChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedDateFormatChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.SelectedDateFormatProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1008,6 +1392,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingCustomDateFormatString(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCustomDateFormatString<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCustomDateFormatStringChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCustomDateFormatStringChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.CustomDateFormatStringProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.TextProperty
 
     /// <summary>
@@ -1102,6 +1534,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnText<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<System.String>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.TextProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1204,6 +1684,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingWatermark(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWatermark<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWatermarkChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWatermarkChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty
 
     /// <summary>
@@ -1302,6 +1830,54 @@ public static partial class CalendarDatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseFloatingWatermark(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseFloatingWatermark<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseFloatingWatermarkChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseFloatingWatermarkChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.UseFloatingWatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -1396,6 +1972,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1542,6 +2166,54 @@ public static partial class CalendarDatePickerExtensions
     public static T OnVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<Avalonia.Layout.VerticalAlignment>> handler) where T : Avalonia.Controls.CalendarDatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.CalendarDatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.CalendarDatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.CalendarDatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.CalendarDatePicker.VerticalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/CalendarItem.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/CalendarItem.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class CalendarItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingHeaderBackground(this Avalonia.Controls.Primitives.CalendarItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.CalendarItem OnBindingHeaderBackground(this Avalonia.Controls.Primitives.CalendarItem obj, Action<Avalonia.Controls.Primitives.CalendarItem, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderBackgroundChanged(this Avalonia.Controls.Primitives.CalendarItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.CalendarItem OnHeaderBackgroundChanged(this Avalonia.Controls.Primitives.CalendarItem obj, Action<Avalonia.Controls.Primitives.CalendarItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.CalendarItem.HeaderBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class CalendarItemExtensions
     public static Avalonia.Controls.Primitives.CalendarItem OnDayTitleTemplate(this Avalonia.Controls.Primitives.CalendarItem obj, Action<Avalonia.Controls.Primitives.CalendarItem, IObservable<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> ObserveBindingDayTitleTemplate(this Avalonia.Controls.Primitives.CalendarItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.CalendarItem OnBindingDayTitleTemplate(this Avalonia.Controls.Primitives.CalendarItem obj, Action<Avalonia.Controls.Primitives.CalendarItem, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDayTitleTemplateChanged(this Avalonia.Controls.Primitives.CalendarItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.CalendarItem OnDayTitleTemplateChanged(this Avalonia.Controls.Primitives.CalendarItem obj, Action<Avalonia.Controls.Primitives.CalendarItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.CalendarItem.DayTitleTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Canvas.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Canvas.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class CanvasExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Canvas.LeftProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingLeft(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Canvas.LeftProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Canvas.LeftProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLeft<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Canvas.LeftProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Canvas.LeftProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLeftChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.LeftProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Canvas.LeftProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLeftChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.LeftProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Canvas.TopProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class CanvasExtensions
     public static T OnTop<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Double>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Canvas.TopProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Canvas.TopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingTop(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Canvas.TopProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Canvas.TopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTop<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Canvas.TopProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Canvas.TopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTopChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.TopProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Canvas.TopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTopChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.TopProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class CanvasExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Canvas.RightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRight(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Canvas.RightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Canvas.RightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRight<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Canvas.RightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Canvas.RightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRightChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.RightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Canvas.RightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRightChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.RightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Canvas.BottomProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class CanvasExtensions
     public static T OnBottom<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Double>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Canvas.BottomProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Canvas.BottomProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingBottom(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Canvas.BottomProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Canvas.BottomProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBottom<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Canvas.BottomProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Canvas.BottomProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBottomChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.BottomProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Canvas.BottomProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBottomChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Canvas.BottomProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Carousel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Carousel.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class CarouselExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Carousel.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.IPageTransition>> ObserveBindingPageTransition(this Avalonia.Controls.Carousel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Carousel.PageTransitionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Carousel.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPageTransition<T>(this T obj, Action<Avalonia.Controls.Carousel, IObservable<BindingValue<Avalonia.Animation.IPageTransition>>> handler) where T : Avalonia.Controls.Carousel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Carousel.PageTransitionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Carousel.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePageTransitionChanged(this Avalonia.Controls.Carousel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Carousel.PageTransitionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Carousel.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPageTransitionChanged<T>(this T obj, Action<Avalonia.Controls.Carousel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Carousel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Carousel.PageTransitionProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/ColorPicker.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ColorPicker.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ColorPickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorPicker.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingContent(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorPicker.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorPicker.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContent<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorPicker.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorPicker.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentChanged(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorPicker.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentChanged<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorPicker.ContentTemplateProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ColorPickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorPicker.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingContentTemplate(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorPicker.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorPicker.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContentTemplate<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorPicker.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorPicker.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTemplateChanged(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorPicker.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ColorPickerExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.ColorPicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -442,6 +586,54 @@ public static partial class ColorPickerExtensions
     public static T OnVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<Avalonia.Layout.VerticalAlignment>> handler) where T : Avalonia.Controls.ColorPicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.ColorPicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.ColorPicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorPicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorPicker.VerticalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ColorPreviewer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ColorPreviewer.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ColorPreviewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.HsvColor>> ObserveBindingHsvColor(this Avalonia.Controls.Primitives.ColorPreviewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHsvColor<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorPreviewer, IObservable<BindingValue<Avalonia.Media.HsvColor>>> handler) where T : Avalonia.Controls.Primitives.ColorPreviewer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHsvColorChanged(this Avalonia.Controls.Primitives.ColorPreviewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHsvColorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorPreviewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorPreviewer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorPreviewer.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ColorPreviewerExtensions
     public static T OnIsAccentColorsVisible<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorPreviewer, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.ColorPreviewer
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsAccentColorsVisible(this Avalonia.Controls.Primitives.ColorPreviewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsAccentColorsVisible<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorPreviewer, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.ColorPreviewer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsAccentColorsVisibleChanged(this Avalonia.Controls.Primitives.ColorPreviewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsAccentColorsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorPreviewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorPreviewer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorPreviewer.IsAccentColorsVisibleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ColorSlider.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ColorSlider.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ColorSliderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingColor(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColor<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<Avalonia.Media.Color>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ColorSliderExtensions
     public static T OnColorComponent<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<Avalonia.Controls.ColorComponent>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorComponent>> ObserveBindingColorComponent(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColorComponent<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<Avalonia.Controls.ColorComponent>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorComponentChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorComponentChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.ColorComponentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -349,6 +445,54 @@ public static partial class ColorSliderExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorModel>> ObserveBindingColorModel(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColorModel<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<Avalonia.Controls.ColorModel>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorModelChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorModelChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.ColorSlider.ColorModelProperty"/> property value to <see cref="Avalonia.Controls.ColorModel.Hsva"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -470,6 +614,54 @@ public static partial class ColorSliderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.HsvColor>> ObserveBindingHsvColor(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHsvColor<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<Avalonia.Media.HsvColor>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHsvColorChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHsvColorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty
 
     /// <summary>
@@ -564,6 +756,54 @@ public static partial class ColorSliderExtensions
     public static T OnIsAlphaVisible<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsAlphaVisible(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsAlphaVisible<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsAlphaVisibleChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsAlphaVisibleChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.IsAlphaVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -666,6 +906,54 @@ public static partial class ColorSliderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsPerceptive(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsPerceptive<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsPerceptiveChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsPerceptiveChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.IsPerceptiveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty
 
     /// <summary>
@@ -760,6 +1048,54 @@ public static partial class ColorSliderExtensions
     public static T OnIsRoundingEnabled<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsRoundingEnabled(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsRoundingEnabled<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsRoundingEnabledChanged(this Avalonia.Controls.Primitives.ColorSlider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsRoundingEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSlider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSlider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSlider.IsRoundingEnabledProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ColorSpectrum.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ColorSpectrum.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ColorSpectrumExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingColor(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColor<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<Avalonia.Media.Color>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ColorSpectrumExtensions
     public static T OnComponents<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<Avalonia.Controls.ColorSpectrumComponents>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorSpectrumComponents>> ObserveBindingComponents(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingComponents<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<Avalonia.Controls.ColorSpectrumComponents>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveComponentsChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnComponentsChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ComponentsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -372,6 +468,54 @@ public static partial class ColorSpectrumExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.HsvColor>> ObserveBindingHsvColor(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHsvColor<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<Avalonia.Media.HsvColor>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHsvColorChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHsvColorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty
 
     /// <summary>
@@ -466,6 +610,54 @@ public static partial class ColorSpectrumExtensions
     public static T OnMaxHue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxHue(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxHue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxHueChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxHueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxHueProperty);
         handler(obj, observable);
         return obj;
     }
@@ -568,6 +760,54 @@ public static partial class ColorSpectrumExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxSaturation(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxSaturation<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxSaturationChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxSaturationChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty
 
     /// <summary>
@@ -662,6 +902,54 @@ public static partial class ColorSpectrumExtensions
     public static T OnMaxValue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxValue(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxValue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxValueChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MaxValueProperty);
         handler(obj, observable);
         return obj;
     }
@@ -764,6 +1052,54 @@ public static partial class ColorSpectrumExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinHue(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinHue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinHueChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinHueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty
 
     /// <summary>
@@ -862,6 +1198,54 @@ public static partial class ColorSpectrumExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinSaturation(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinSaturation<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinSaturationChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinSaturationChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty
 
     /// <summary>
@@ -956,6 +1340,54 @@ public static partial class ColorSpectrumExtensions
     public static T OnMinValue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinValue(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinValue<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinValueChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.MinValueProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1059,6 +1491,54 @@ public static partial class ColorSpectrumExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorSpectrumShape>> ObserveBindingShape(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShape<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<Avalonia.Controls.ColorSpectrumShape>>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShapeChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShapeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ColorSpectrum
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ShapeProperty"/> property value to <see cref="Avalonia.Controls.ColorSpectrumShape.Box"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1122,6 +1602,52 @@ public static partial class ColorSpectrumExtensions
     public static Avalonia.Controls.Primitives.ColorSpectrum OnThirdComponent(this Avalonia.Controls.Primitives.ColorSpectrum obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<Avalonia.Controls.ColorComponent>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorComponent>> ObserveBindingThirdComponent(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.ColorSpectrum OnBindingThirdComponent(this Avalonia.Controls.Primitives.ColorSpectrum obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<BindingValue<Avalonia.Controls.ColorComponent>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveThirdComponentChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.ColorSpectrum OnThirdComponentChanged(this Avalonia.Controls.Primitives.ColorSpectrum obj, Action<Avalonia.Controls.Primitives.ColorSpectrum, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ColorSpectrum.ThirdComponentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ColorView.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ColorView.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingColor(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColor<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Media.Color>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.ColorModelProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ColorViewExtensions
     public static T OnColorModel<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<Avalonia.Controls.ColorModel>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.ColorModelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorModel>> ObserveBindingColorModel(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorModelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColorModel<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Controls.ColorModel>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorModelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorModelChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorModelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.ColorModelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorModelChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorModelProperty);
         handler(obj, observable);
         return obj;
     }
@@ -320,6 +416,54 @@ public static partial class ColorViewExtensions
     public static T OnColorSpectrumComponents<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<Avalonia.Controls.ColorSpectrumComponents>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorSpectrumComponents>> ObserveBindingColorSpectrumComponents(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColorSpectrumComponents<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Controls.ColorSpectrumComponents>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorSpectrumComponentsChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorSpectrumComponentsChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorSpectrumComponentsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -495,6 +639,54 @@ public static partial class ColorViewExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ColorSpectrumShape>> ObserveBindingColorSpectrumShape(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorSpectrumShapeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColorSpectrumShape<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Controls.ColorSpectrumShape>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.ColorSpectrumShapeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorSpectrumShapeChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorSpectrumShapeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.ColorSpectrumShapeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorSpectrumShapeChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.ColorSpectrumShapeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ColorView.ColorSpectrumShapeProperty"/> property value to <see cref="Avalonia.Controls.ColorSpectrumShape.Box"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -612,6 +804,54 @@ public static partial class ColorViewExtensions
     public static T OnHexInputAlphaPosition<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<Avalonia.Controls.AlphaComponentPosition>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.HexInputAlphaPositionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.HexInputAlphaPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.AlphaComponentPosition>> ObserveBindingHexInputAlphaPosition(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.HexInputAlphaPositionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.HexInputAlphaPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHexInputAlphaPosition<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Controls.AlphaComponentPosition>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.HexInputAlphaPositionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.HexInputAlphaPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHexInputAlphaPositionChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.HexInputAlphaPositionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.HexInputAlphaPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHexInputAlphaPositionChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.HexInputAlphaPositionProperty);
         handler(obj, observable);
         return obj;
     }
@@ -738,6 +978,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.HsvColor>> ObserveBindingHsvColor(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHsvColor<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Media.HsvColor>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHsvColorChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.HsvColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.HsvColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHsvColorChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.HsvColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty
 
     /// <summary>
@@ -832,6 +1120,54 @@ public static partial class ColorViewExtensions
     public static T OnIsAccentColorsVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsAccentColorsVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsAccentColorsVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsAccentColorsVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsAccentColorsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsAccentColorsVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -934,6 +1270,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsAlphaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsAlphaEnabled(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsAlphaEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsAlphaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsAlphaEnabled<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsAlphaEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsAlphaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsAlphaEnabledChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsAlphaEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsAlphaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsAlphaEnabledChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsAlphaEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.IsAlphaVisibleProperty
 
     /// <summary>
@@ -1028,6 +1412,54 @@ public static partial class ColorViewExtensions
     public static T OnIsAlphaVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.IsAlphaVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsAlphaVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsAlphaVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsAlphaVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsAlphaVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsAlphaVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsAlphaVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsAlphaVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsAlphaVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsAlphaVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1130,6 +1562,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsColorComponentsVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsColorComponentsVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsColorComponentsVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsColorComponentsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorComponentsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.IsColorModelVisibleProperty
 
     /// <summary>
@@ -1224,6 +1704,54 @@ public static partial class ColorViewExtensions
     public static T OnIsColorModelVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.IsColorModelVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorModelVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsColorModelVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorModelVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorModelVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsColorModelVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorModelVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsColorModelVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsColorModelVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorModelVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsColorModelVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsColorModelVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorModelVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1326,6 +1854,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsColorPaletteVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsColorPaletteVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsColorPaletteVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsColorPaletteVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorPaletteVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty
 
     /// <summary>
@@ -1420,6 +1996,54 @@ public static partial class ColorViewExtensions
     public static T OnIsColorPreviewVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsColorPreviewVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsColorPreviewVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsColorPreviewVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsColorPreviewVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorPreviewVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1522,6 +2146,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsColorSpectrumVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsColorSpectrumVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsColorSpectrumVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsColorSpectrumVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorSpectrumVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty
 
     /// <summary>
@@ -1616,6 +2288,54 @@ public static partial class ColorViewExtensions
     public static T OnIsColorSpectrumSliderVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsColorSpectrumSliderVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsColorSpectrumSliderVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsColorSpectrumSliderVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsColorSpectrumSliderVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsColorSpectrumSliderVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1718,6 +2438,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsComponentSliderVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsComponentSliderVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsComponentSliderVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsComponentSliderVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsComponentSliderVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty
 
     /// <summary>
@@ -1812,6 +2580,54 @@ public static partial class ColorViewExtensions
     public static T OnIsComponentTextInputVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsComponentTextInputVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsComponentTextInputVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsComponentTextInputVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsComponentTextInputVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsComponentTextInputVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1914,6 +2730,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.IsHexInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsHexInputVisible(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.IsHexInputVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.IsHexInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsHexInputVisible<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.IsHexInputVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.IsHexInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsHexInputVisibleChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsHexInputVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.IsHexInputVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsHexInputVisibleChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.IsHexInputVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.MaxHueProperty
 
     /// <summary>
@@ -2008,6 +2872,54 @@ public static partial class ColorViewExtensions
     public static T OnMaxHue<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Int32>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.MaxHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxHue(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.MaxHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxHue<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.MaxHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxHueChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MaxHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.MaxHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxHueChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MaxHueProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2110,6 +3022,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxSaturation(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.MaxSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxSaturation<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.MaxSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxSaturationChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MaxSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.MaxSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxSaturationChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MaxSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.MaxValueProperty
 
     /// <summary>
@@ -2204,6 +3164,54 @@ public static partial class ColorViewExtensions
     public static T OnMaxValue<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Int32>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.MaxValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxValue(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.MaxValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxValue<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.MaxValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxValueChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MaxValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.MaxValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxValueChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MaxValueProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2306,6 +3314,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinHue(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.MinHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinHue<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.MinHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinHueChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MinHueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.MinHueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinHueChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MinHueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.MinSaturationProperty
 
     /// <summary>
@@ -2400,6 +3456,54 @@ public static partial class ColorViewExtensions
     public static T OnMinSaturation<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Int32>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.MinSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinSaturation(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.MinSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinSaturation<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.MinSaturationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinSaturationChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MinSaturationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.MinSaturationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinSaturationChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MinSaturationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2502,6 +3606,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinValue(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.MinValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinValue<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.MinValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinValueChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MinValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.MinValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinValueChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.MinValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.PaletteColorsProperty
 
     /// <summary>
@@ -2596,6 +3748,54 @@ public static partial class ColorViewExtensions
     public static T OnPaletteColors<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Collections.Generic.IEnumerable<Avalonia.Media.Color>>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.PaletteColorsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.PaletteColorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IEnumerable<Avalonia.Media.Color>>> ObserveBindingPaletteColors(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.PaletteColorsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.PaletteColorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPaletteColors<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Collections.Generic.IEnumerable<Avalonia.Media.Color>>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.PaletteColorsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.PaletteColorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaletteColorsChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.PaletteColorsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.PaletteColorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaletteColorsChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.PaletteColorsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2698,6 +3898,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.PaletteColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingPaletteColumnCount(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.PaletteColumnCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.PaletteColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPaletteColumnCount<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.PaletteColumnCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.PaletteColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaletteColumnCountChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.PaletteColumnCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.PaletteColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaletteColumnCountChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.PaletteColumnCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.PaletteProperty
 
     /// <summary>
@@ -2796,6 +4044,54 @@ public static partial class ColorViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.PaletteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.IColorPalette>> ObserveBindingPalette(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.PaletteProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.PaletteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPalette<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<Avalonia.Controls.IColorPalette>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.PaletteProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.PaletteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaletteChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.PaletteProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.PaletteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaletteChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.PaletteProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColorView.SelectedIndexProperty
 
     /// <summary>
@@ -2890,6 +4186,54 @@ public static partial class ColorViewExtensions
     public static T OnSelectedIndex<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<System.Int32>> handler) where T : Avalonia.Controls.ColorView
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColorView.SelectedIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColorView.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectedIndex(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColorView.SelectedIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColorView.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedIndex<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColorView.SelectedIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColorView.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedIndexChanged(this Avalonia.Controls.ColorView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.SelectedIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColorView.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedIndexChanged<T>(this T obj, Action<Avalonia.Controls.ColorView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColorView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColorView.SelectedIndexProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ColumnDefinition.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ColumnDefinition.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ColumnDefinitionExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColumnDefinition.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxWidth(this Avalonia.Controls.ColumnDefinition obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColumnDefinition.MaxWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColumnDefinition.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxWidth<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ColumnDefinition
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColumnDefinition.MaxWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColumnDefinition.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxWidthChanged(this Avalonia.Controls.ColumnDefinition obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColumnDefinition.MaxWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColumnDefinition.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxWidthChanged<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColumnDefinition
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColumnDefinition.MaxWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColumnDefinition.MinWidthProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ColumnDefinitionExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColumnDefinition.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinWidth(this Avalonia.Controls.ColumnDefinition obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColumnDefinition.MinWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColumnDefinition.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinWidth<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ColumnDefinition
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColumnDefinition.MinWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColumnDefinition.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinWidthChanged(this Avalonia.Controls.ColumnDefinition obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColumnDefinition.MinWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColumnDefinition.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinWidthChanged<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColumnDefinition
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColumnDefinition.MinWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ColumnDefinition.WidthProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ColumnDefinitionExtensions
     public static T OnWidth<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<Avalonia.Controls.GridLength>> handler) where T : Avalonia.Controls.ColumnDefinition
     {
         var observable = obj.GetObservable(Avalonia.Controls.ColumnDefinition.WidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ColumnDefinition.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.GridLength>> ObserveBindingWidth(this Avalonia.Controls.ColumnDefinition obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ColumnDefinition.WidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ColumnDefinition.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWidth<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<BindingValue<Avalonia.Controls.GridLength>>> handler) where T : Avalonia.Controls.ColumnDefinition
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ColumnDefinition.WidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ColumnDefinition.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWidthChanged(this Avalonia.Controls.ColumnDefinition obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ColumnDefinition.WidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ColumnDefinition.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWidthChanged<T>(this T obj, Action<Avalonia.Controls.ColumnDefinition, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ColumnDefinition
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ColumnDefinition.WidthProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/CombinedGeometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/CombinedGeometry.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class CombinedGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingGeometry1(this Avalonia.Media.CombinedGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.CombinedGeometry.Geometry1Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGeometry1<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler) where T : Avalonia.Media.CombinedGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.CombinedGeometry.Geometry1Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGeometry1Changed(this Avalonia.Media.CombinedGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.CombinedGeometry.Geometry1Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGeometry1Changed<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.CombinedGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.CombinedGeometry.Geometry1Property);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.CombinedGeometry.Geometry2Property
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class CombinedGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingGeometry2(this Avalonia.Media.CombinedGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.CombinedGeometry.Geometry2Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGeometry2<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler) where T : Avalonia.Media.CombinedGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.CombinedGeometry.Geometry2Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGeometry2Changed(this Avalonia.Media.CombinedGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.CombinedGeometry.Geometry2Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.CombinedGeometry.Geometry2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGeometry2Changed<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.CombinedGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.CombinedGeometry.Geometry2Property);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class CombinedGeometryExtensions
     public static T OnGeometryCombineMode<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<Avalonia.Media.GeometryCombineMode>> handler) where T : Avalonia.Media.CombinedGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.GeometryCombineMode>> ObserveBindingGeometryCombineMode(this Avalonia.Media.CombinedGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGeometryCombineMode<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<BindingValue<Avalonia.Media.GeometryCombineMode>>> handler) where T : Avalonia.Media.CombinedGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGeometryCombineModeChanged(this Avalonia.Media.CombinedGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGeometryCombineModeChanged<T>(this T obj, Action<Avalonia.Media.CombinedGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.CombinedGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.CombinedGeometry.GeometryCombineModeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ComboBox.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ComboBox.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ComboBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDropDownOpen(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.IsDropDownOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDropDownOpen<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.IsDropDownOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDropDownOpenChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.IsDropDownOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.IsDropDownOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDropDownOpenChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.IsDropDownOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ComboBox.MaxDropDownHeightProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ComboBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxDropDownHeight(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.MaxDropDownHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxDropDownHeight<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.MaxDropDownHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxDropDownHeightChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.MaxDropDownHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.MaxDropDownHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxDropDownHeightChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.MaxDropDownHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ComboBox.SelectionBoxItemProperty
 
     /// <summary>
@@ -242,6 +338,52 @@ public static partial class ComboBoxExtensions
     public static Avalonia.Controls.ComboBox OnSelectionBoxItem(this Avalonia.Controls.ComboBox obj, Action<Avalonia.Controls.ComboBox, IObservable<System.Object>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ComboBox.SelectionBoxItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectionBoxItem(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.SelectionBoxItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ComboBox OnBindingSelectionBoxItem(this Avalonia.Controls.ComboBox obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<System.Object>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.SelectionBoxItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionBoxItemChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.SelectionBoxItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ComboBox OnSelectionBoxItemChanged(this Avalonia.Controls.ComboBox obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.SelectionBoxItemProperty);
         handler(obj, observable);
         return obj;
     }
@@ -344,6 +486,54 @@ public static partial class ComboBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingPlaceholderText(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.PlaceholderTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlaceholderText<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.PlaceholderTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlaceholderTextChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.PlaceholderTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlaceholderTextChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.PlaceholderTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ComboBox.PlaceholderForegroundProperty
 
     /// <summary>
@@ -442,6 +632,54 @@ public static partial class ComboBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingPlaceholderForeground(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.PlaceholderForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlaceholderForeground<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.PlaceholderForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlaceholderForegroundChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.PlaceholderForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.PlaceholderForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlaceholderForegroundChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.PlaceholderForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -536,6 +774,54 @@ public static partial class ComboBoxExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.ComboBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -687,6 +973,54 @@ public static partial class ComboBoxExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ComboBox.VerticalContentAlignmentProperty"/> property value to <see cref="Avalonia.Layout.VerticalAlignment.Stretch"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -828,6 +1162,54 @@ public static partial class ComboBoxExtensions
     public static T OnSelectionBoxItemTemplate<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.ComboBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingSelectionBoxItemTemplate(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionBoxItemTemplate<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionBoxItemTemplateChanged(this Avalonia.Controls.ComboBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionBoxItemTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ComboBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ComboBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ComboBox.SelectionBoxItemTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ConicGradientBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ConicGradientBrush.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class ConicGradientBrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ConicGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingCenter(this Avalonia.Media.ConicGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ConicGradientBrush.CenterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ConicGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ConicGradientBrush OnBindingCenter(this Avalonia.Media.ConicGradientBrush obj, Action<Avalonia.Media.ConicGradientBrush, IObservable<BindingValue<Avalonia.RelativePoint>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ConicGradientBrush.CenterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ConicGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterChanged(this Avalonia.Media.ConicGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ConicGradientBrush.CenterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ConicGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ConicGradientBrush OnCenterChanged(this Avalonia.Media.ConicGradientBrush obj, Action<Avalonia.Media.ConicGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ConicGradientBrush.CenterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ConicGradientBrush.AngleProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class ConicGradientBrushExtensions
     public static Avalonia.Media.ConicGradientBrush OnAngle(this Avalonia.Media.ConicGradientBrush obj, Action<Avalonia.Media.ConicGradientBrush, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.ConicGradientBrush.AngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ConicGradientBrush.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngle(this Avalonia.Media.ConicGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ConicGradientBrush.AngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ConicGradientBrush.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ConicGradientBrush OnBindingAngle(this Avalonia.Media.ConicGradientBrush obj, Action<Avalonia.Media.ConicGradientBrush, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ConicGradientBrush.AngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ConicGradientBrush.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleChanged(this Avalonia.Media.ConicGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ConicGradientBrush.AngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ConicGradientBrush.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ConicGradientBrush OnAngleChanged(this Avalonia.Media.ConicGradientBrush obj, Action<Avalonia.Media.ConicGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ConicGradientBrush.AngleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ContentControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ContentControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ContentControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContentControl.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingContent(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContentControl.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContentControl.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContent<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContentControl.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContentControl.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentChanged(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContentControl.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentChanged<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ContentControl.ContentTemplateProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ContentControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContentControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingContentTemplate(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContentControl.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContentControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContentTemplate<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContentControl.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContentControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTemplateChanged(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContentControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ContentControlExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.ContentControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -442,6 +586,54 @@ public static partial class ContentControlExtensions
     public static T OnVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<Avalonia.Layout.VerticalAlignment>> handler) where T : Avalonia.Controls.ContentControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.ContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.ContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContentControl.VerticalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ContentPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ContentPresenter.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ContentPresenterExtensions
     public static T OnBackgroundSizing<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Media.BackgroundSizing>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.BackgroundSizing>> ObserveBindingBackgroundSizing(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackgroundSizing<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.BackgroundSizing>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundSizingChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundSizingChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BackgroundSizingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -336,6 +432,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBorderBrush(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBorderBrush<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBorderBrushChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBorderBrushChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty
 
     /// <summary>
@@ -430,6 +574,54 @@ public static partial class ContentPresenterExtensions
     public static T OnBorderThickness<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Thickness>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingBorderThickness(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBorderThickness<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBorderThicknessChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBorderThicknessChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BorderThicknessProperty);
         handler(obj, observable);
         return obj;
     }
@@ -532,6 +724,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.CornerRadius>> ObserveBindingCornerRadius(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCornerRadius<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.CornerRadius>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCornerRadiusChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCornerRadiusChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty
 
     /// <summary>
@@ -626,6 +866,54 @@ public static partial class ContentPresenterExtensions
     public static T OnBoxShadow<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Media.BoxShadows>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.BoxShadows>> ObserveBindingBoxShadow(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBoxShadow<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.BoxShadows>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBoxShadowChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBoxShadowChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.BoxShadowProperty);
         handler(obj, observable);
         return obj;
     }
@@ -728,6 +1016,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingForeground(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingForeground<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveForegroundChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnForegroundChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty
 
     /// <summary>
@@ -822,6 +1158,54 @@ public static partial class ContentPresenterExtensions
     public static T OnFontFamily<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Media.FontFamily>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFamily>> ObserveBindingFontFamily(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFamily<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.FontFamily>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFamilyChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFamilyChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontFamilyProperty);
         handler(obj, observable);
         return obj;
     }
@@ -924,6 +1308,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingFontSize(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontSize<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontSizeChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontSizeChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty
 
     /// <summary>
@@ -1018,6 +1450,54 @@ public static partial class ContentPresenterExtensions
     public static T OnFontStyle<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Media.FontStyle>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStyle>> ObserveBindingFontStyle(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStyle<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.FontStyle>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStyleChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStyleChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStyleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1152,6 +1632,54 @@ public static partial class ContentPresenterExtensions
     public static T OnFontWeight<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Media.FontWeight>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontWeight>> ObserveBindingFontWeight(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontWeight<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.FontWeight>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontWeightChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontWeightChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontWeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1471,6 +1999,54 @@ public static partial class ContentPresenterExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStretch>> ObserveBindingFontStretch(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStretch<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Media.FontStretch>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStretchChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStretchChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Presenters.ContentPresenter.FontStretchProperty"/> property value to <see cref="Avalonia.Media.FontStretch.UltraCondensed"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1622,6 +2198,52 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingChild(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Presenters.ContentPresenter OnBindingChild(this Avalonia.Controls.Presenters.ContentPresenter obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Controls.Control>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Presenters.ContentPresenter OnChildChanged(this Avalonia.Controls.Presenters.ContentPresenter obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.ContentProperty
 
     /// <summary>
@@ -1716,6 +2338,54 @@ public static partial class ContentPresenterExtensions
     public static T OnContent<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<System.Object>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingContent(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContent<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1818,6 +2488,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingContentTemplate(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContentTemplate<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTemplateChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -1912,6 +2630,54 @@ public static partial class ContentPresenterExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2063,6 +2829,54 @@ public static partial class ContentPresenterExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Presenters.ContentPresenter.VerticalContentAlignmentProperty"/> property value to <see cref="Avalonia.Layout.VerticalAlignment.Stretch"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -2208,6 +3022,54 @@ public static partial class ContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingPadding(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPadding<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaddingChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaddingChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty
 
     /// <summary>
@@ -2302,6 +3164,54 @@ public static partial class ContentPresenterExtensions
     public static T OnRecognizesAccessKey<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingRecognizesAccessKey(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRecognizesAccessKey<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRecognizesAccessKeyChanged(this Avalonia.Controls.Presenters.ContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRecognizesAccessKeyChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ContentPresenter.RecognizesAccessKeyProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ContextMenu.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ContextMenu.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ContextMenuExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalOffset(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalOffset<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalOffsetChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ContextMenu.VerticalOffsetProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ContextMenuExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalOffset(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalOffset<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalOffsetChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ContextMenu.PlacementAnchorProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ContextMenuExtensions
     public static T OnPlacementAnchor<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>> handler) where T : Avalonia.Controls.ContextMenu
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContextMenu.PlacementAnchorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>> ObserveBindingPlacementAnchor(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementAnchorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementAnchor<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementAnchorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementAnchorChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementAnchorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementAnchorChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementAnchorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -543,6 +687,54 @@ public static partial class ContextMenuExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>> ObserveBindingPlacementConstraintAdjustment(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementConstraintAdjustment<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementConstraintAdjustmentChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementConstraintAdjustmentChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ContextMenu.PlacementConstraintAdjustmentProperty"/> property value to <see cref="Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -732,6 +924,54 @@ public static partial class ContextMenuExtensions
     public static T OnPlacementGravity<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>> handler) where T : Avalonia.Controls.ContextMenu
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContextMenu.PlacementGravityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>> ObserveBindingPlacementGravity(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementGravityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementGravity<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementGravityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementGravityChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementGravityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementGravityChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementGravityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -938,6 +1178,54 @@ public static partial class ContextMenuExtensions
     public static T OnPlacement<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<Avalonia.Controls.PlacementMode>> handler) where T : Avalonia.Controls.ContextMenu
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContextMenu.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.PlacementMode>> ObserveBindingPlacement(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacement<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<Avalonia.Controls.PlacementMode>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1232,6 +1520,54 @@ public static partial class ContextMenuExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<Avalonia.Rect>>> ObserveBindingPlacementRect(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementRect<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<System.Nullable<Avalonia.Rect>>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementRectChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementRectChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty
 
     /// <summary>
@@ -1326,6 +1662,54 @@ public static partial class ContextMenuExtensions
     public static T OnWindowManagerAddShadowHint<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.ContextMenu
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingWindowManagerAddShadowHint(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWindowManagerAddShadowHint<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWindowManagerAddShadowHintChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWindowManagerAddShadowHintChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.WindowManagerAddShadowHintProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1428,6 +1812,54 @@ public static partial class ContextMenuExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingPlacementTarget(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementTargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementTarget<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.PlacementTargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementTargetChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementTargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementTargetChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.PlacementTargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty
 
     /// <summary>
@@ -1522,6 +1954,54 @@ public static partial class ContextMenuExtensions
     public static T OnCustomPopupPlacementCallback<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>> handler) where T : Avalonia.Controls.ContextMenu
     {
         var observable = obj.GetObservable(Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>> ObserveBindingCustomPopupPlacementCallback(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCustomPopupPlacementCallback<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCustomPopupPlacementCallbackChanged(this Avalonia.Controls.ContextMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCustomPopupPlacementCallbackChanged<T>(this T obj, Action<Avalonia.Controls.ContextMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ContextMenu
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ContextMenu.CustomPopupPlacementCallbackProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Control.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Control.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Control.FocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> ObserveBindingFocusAdorner(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Control.FocusAdornerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Control.FocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFocusAdorner<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Control.FocusAdornerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Control.FocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFocusAdornerChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Control.FocusAdornerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Control.FocusAdornerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFocusAdornerChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Control.FocusAdornerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Control.TagProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ControlExtensions
     public static T OnTag<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Object>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Control.TagProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Control.TagProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingTag(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Control.TagProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Control.TagProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTag<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Control.TagProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Control.TagProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTagChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Control.TagProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Control.TagProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTagChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Control.TagProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class ControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Control.ContextMenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ContextMenu>> ObserveBindingContextMenu(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Control.ContextMenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Control.ContextMenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContextMenu<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.ContextMenu>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Control.ContextMenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Control.ContextMenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContextMenuChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Control.ContextMenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Control.ContextMenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContextMenuChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Control.ContextMenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Control.ContextFlyoutProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class ControlExtensions
     public static T OnContextFlyout<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Controls.Primitives.FlyoutBase>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Control.ContextFlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Control.ContextFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>> ObserveBindingContextFlyout(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Control.ContextFlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Control.ContextFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContextFlyout<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Control.ContextFlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Control.ContextFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContextFlyoutChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Control.ContextFlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Control.ContextFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContextFlyoutChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Control.ContextFlyoutProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/CroppedBitmap.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/CroppedBitmap.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class CroppedBitmapExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IImage>> ObserveBindingSource(this Avalonia.Media.Imaging.CroppedBitmap obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSource<T>(this T obj, Action<Avalonia.Media.Imaging.CroppedBitmap, IObservable<BindingValue<Avalonia.Media.IImage>>> handler) where T : Avalonia.Media.Imaging.CroppedBitmap
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSourceChanged(this Avalonia.Media.Imaging.CroppedBitmap obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSourceChanged<T>(this T obj, Action<Avalonia.Media.Imaging.CroppedBitmap, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.Imaging.CroppedBitmap
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class CroppedBitmapExtensions
     public static T OnSourceRect<T>(this T obj, Action<Avalonia.Media.Imaging.CroppedBitmap, IObservable<Avalonia.PixelRect>> handler) where T : Avalonia.Media.Imaging.CroppedBitmap
     {
         var observable = obj.GetObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.PixelRect>> ObserveBindingSourceRect(this Avalonia.Media.Imaging.CroppedBitmap obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSourceRect<T>(this T obj, Action<Avalonia.Media.Imaging.CroppedBitmap, IObservable<BindingValue<Avalonia.PixelRect>>> handler) where T : Avalonia.Media.Imaging.CroppedBitmap
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSourceRectChanged(this Avalonia.Media.Imaging.CroppedBitmap obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSourceRectChanged<T>(this T obj, Action<Avalonia.Media.Imaging.CroppedBitmap, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.Imaging.CroppedBitmap
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Imaging.CroppedBitmap.SourceRectProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DashStyle.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DashStyle.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class DashStyleExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DashStyle.DashesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>> ObserveBindingDashes(this Avalonia.Media.DashStyle obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DashStyle.DashesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DashStyle.DashesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DashStyle OnBindingDashes(this Avalonia.Media.DashStyle obj, Action<Avalonia.Media.DashStyle, IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DashStyle.DashesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DashStyle.DashesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDashesChanged(this Avalonia.Media.DashStyle obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DashStyle.DashesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DashStyle.DashesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DashStyle OnDashesChanged(this Avalonia.Media.DashStyle obj, Action<Avalonia.Media.DashStyle, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DashStyle.DashesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DashStyle.OffsetProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class DashStyleExtensions
     public static Avalonia.Media.DashStyle OnOffset(this Avalonia.Media.DashStyle obj, Action<Avalonia.Media.DashStyle, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.DashStyle.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DashStyle.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOffset(this Avalonia.Media.DashStyle obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DashStyle.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DashStyle.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DashStyle OnBindingOffset(this Avalonia.Media.DashStyle obj, Action<Avalonia.Media.DashStyle, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DashStyle.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DashStyle.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffsetChanged(this Avalonia.Media.DashStyle obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DashStyle.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DashStyle.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DashStyle OnOffsetChanged(this Avalonia.Media.DashStyle obj, Action<Avalonia.Media.DashStyle, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DashStyle.OffsetProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGrid.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGrid.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUserReorderColumns(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanUserReorderColumns<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUserReorderColumnsChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanUserReorderColumnsChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CanUserReorderColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataGridExtensions
     public static T OnCanUserResizeColumns<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUserResizeColumns(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanUserResizeColumns<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUserResizeColumnsChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanUserResizeColumnsChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CanUserResizeColumnsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUserSortColumns(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.CanUserSortColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanUserSortColumns<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.CanUserSortColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUserSortColumnsChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CanUserSortColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanUserSortColumnsChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CanUserSortColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class DataGridExtensions
     public static T OnColumnHeaderHeight<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Double>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingColumnHeaderHeight(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumnHeaderHeight<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnHeaderHeightChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnHeaderHeightChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ColumnHeaderHeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.ColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridLength>> ObserveBindingColumnWidth(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.ColumnWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.ColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumnWidth<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.DataGridLength>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.ColumnWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.ColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnWidthChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ColumnWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.ColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnWidthChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ColumnWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.RowThemeProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class DataGridExtensions
     public static T OnRowTheme<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Styling.ControlTheme>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.RowThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingRowTheme(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowTheme<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowThemeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowThemeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowThemeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingCellTheme(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.CellThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCellTheme<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.CellThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCellThemeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CellThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCellThemeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CellThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class DataGridExtensions
     public static T OnColumnHeaderTheme<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Styling.ControlTheme>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingColumnHeaderTheme(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumnHeaderTheme<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnHeaderThemeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnHeaderThemeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ColumnHeaderThemeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -888,6 +1272,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowGroupThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingRowGroupTheme(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowGroupThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowGroupThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowGroupTheme<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowGroupThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowGroupThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowGroupThemeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowGroupThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowGroupThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowGroupThemeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowGroupThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.FrozenColumnCountProperty
 
     /// <summary>
@@ -986,6 +1418,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.FrozenColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingFrozenColumnCount(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.FrozenColumnCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.FrozenColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFrozenColumnCount<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.FrozenColumnCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.FrozenColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFrozenColumnCountChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.FrozenColumnCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.FrozenColumnCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFrozenColumnCountChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.FrozenColumnCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.GridLinesVisibilityProperty
 
     /// <summary>
@@ -1080,6 +1560,54 @@ public static partial class DataGridExtensions
     public static T OnGridLinesVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Controls.DataGridGridLinesVisibility>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.GridLinesVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.GridLinesVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridGridLinesVisibility>> ObserveBindingGridLinesVisibility(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.GridLinesVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.GridLinesVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGridLinesVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.DataGridGridLinesVisibility>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.GridLinesVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.GridLinesVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGridLinesVisibilityChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.GridLinesVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.GridLinesVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGridLinesVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.GridLinesVisibilityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1231,6 +1759,54 @@ public static partial class DataGridExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.HeadersVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridHeadersVisibility>> ObserveBindingHeadersVisibility(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.HeadersVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.HeadersVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeadersVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.DataGridHeadersVisibility>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.HeadersVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.HeadersVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeadersVisibilityChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.HeadersVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.HeadersVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeadersVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.HeadersVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.DataGrid.HeadersVisibilityProperty"/> property value to <see cref="Avalonia.Controls.DataGridHeadersVisibility.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1376,6 +1952,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingHorizontalGridLinesBrush(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalGridLinesBrush<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalGridLinesBrushChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalGridLinesBrushChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.HorizontalGridLinesBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty
 
     /// <summary>
@@ -1470,6 +2094,54 @@ public static partial class DataGridExtensions
     public static T OnHorizontalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Controls.Primitives.ScrollBarVisibility>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>> ObserveBindingHorizontalScrollBarVisibility(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalScrollBarVisibilityChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalScrollBarVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.HorizontalScrollBarVisibilityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1620,6 +2292,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsReadOnly(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsReadOnly<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsReadOnlyChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsReadOnlyChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty
 
     /// <summary>
@@ -1718,6 +2438,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreRowGroupHeadersFrozen(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreRowGroupHeadersFrozen<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreRowGroupHeadersFrozenChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreRowGroupHeadersFrozenChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.AreRowGroupHeadersFrozenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.IsValidProperty
 
     /// <summary>
@@ -1758,6 +2526,52 @@ public static partial class DataGridExtensions
     public static Avalonia.Controls.DataGrid OnIsValid(this Avalonia.Controls.DataGrid obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.IsValidProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsValid(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.IsValidProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGrid OnBindingIsValid(this Avalonia.Controls.DataGrid obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.IsValidProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsValidChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.IsValidProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGrid OnIsValidChanged(this Avalonia.Controls.DataGrid obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.IsValidProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1860,6 +2674,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.MaxColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxColumnWidth(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.MaxColumnWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.MaxColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxColumnWidth<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.MaxColumnWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.MaxColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxColumnWidthChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.MaxColumnWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.MaxColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxColumnWidthChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.MaxColumnWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.MinColumnWidthProperty
 
     /// <summary>
@@ -1954,6 +2816,54 @@ public static partial class DataGridExtensions
     public static T OnMinColumnWidth<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Double>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.MinColumnWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.MinColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinColumnWidth(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.MinColumnWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.MinColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinColumnWidth<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.MinColumnWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.MinColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinColumnWidthChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.MinColumnWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.MinColumnWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinColumnWidthChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.MinColumnWidthProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2056,6 +2966,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingRowBackground(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowBackground<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowBackgroundChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.RowHeightProperty
 
     /// <summary>
@@ -2150,6 +3108,54 @@ public static partial class DataGridExtensions
     public static T OnRowHeight<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Double>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.RowHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRowHeight(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowHeight<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowHeightChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowHeightChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowHeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2252,6 +3258,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowHeaderWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRowHeaderWidth(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowHeaderWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowHeaderWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowHeaderWidth<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowHeaderWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowHeaderWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowHeaderWidthChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowHeaderWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowHeaderWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowHeaderWidthChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowHeaderWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.SelectionModeProperty
 
     /// <summary>
@@ -2346,6 +3400,54 @@ public static partial class DataGridExtensions
     public static T OnSelectionMode<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Controls.DataGridSelectionMode>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.SelectionModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridSelectionMode>> ObserveBindingSelectionMode(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.SelectionModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionMode<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.DataGridSelectionMode>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.SelectionModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionModeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.SelectionModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionModeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.SelectionModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2472,6 +3574,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingVerticalGridLinesBrush(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalGridLinesBrush<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalGridLinesBrushChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalGridLinesBrushChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.VerticalGridLinesBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty
 
     /// <summary>
@@ -2566,6 +3716,54 @@ public static partial class DataGridExtensions
     public static T OnVerticalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Controls.Primitives.ScrollBarVisibility>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>> ObserveBindingVerticalScrollBarVisibility(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalScrollBarVisibilityChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalScrollBarVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.VerticalScrollBarVisibilityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2716,6 +3914,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> ObserveBindingDropLocationIndicatorTemplate(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDropLocationIndicatorTemplate<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDropLocationIndicatorTemplateChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDropLocationIndicatorTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.DropLocationIndicatorTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.SelectedIndexProperty
 
     /// <summary>
@@ -2810,6 +4056,54 @@ public static partial class DataGridExtensions
     public static T OnSelectedIndex<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Int32>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.SelectedIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectedIndex(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.SelectedIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedIndex<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.SelectedIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedIndexChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.SelectedIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedIndexChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.SelectedIndexProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2912,6 +4206,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectedItem(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedItem<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedItemChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedItemChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.ClipboardCopyModeProperty
 
     /// <summary>
@@ -3006,6 +4348,54 @@ public static partial class DataGridExtensions
     public static T OnClipboardCopyMode<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Controls.DataGridClipboardCopyMode>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.ClipboardCopyModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.ClipboardCopyModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridClipboardCopyMode>> ObserveBindingClipboardCopyMode(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.ClipboardCopyModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.ClipboardCopyModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClipboardCopyMode<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.DataGridClipboardCopyMode>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.ClipboardCopyModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.ClipboardCopyModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClipboardCopyModeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ClipboardCopyModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.ClipboardCopyModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClipboardCopyModeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ClipboardCopyModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -3144,6 +4534,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAutoGenerateColumns(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAutoGenerateColumns<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAutoGenerateColumnsChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAutoGenerateColumnsChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.AutoGenerateColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.ItemsSourceProperty
 
     /// <summary>
@@ -3238,6 +4676,54 @@ public static partial class DataGridExtensions
     public static T OnItemsSource<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<System.Collections.IEnumerable>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.IEnumerable>> ObserveBindingItemsSource(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsSource<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Collections.IEnumerable>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsSourceChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsSourceChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.ItemsSourceProperty);
         handler(obj, observable);
         return obj;
     }
@@ -3340,6 +4826,54 @@ public static partial class DataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreRowDetailsFrozen(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreRowDetailsFrozen<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreRowDetailsFrozenChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreRowDetailsFrozenChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.AreRowDetailsFrozenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGrid.RowDetailsTemplateProperty
 
     /// <summary>
@@ -3434,6 +4968,54 @@ public static partial class DataGridExtensions
     public static T OnRowDetailsTemplate<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.DataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.RowDetailsTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingRowDetailsTemplate(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowDetailsTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowDetailsTemplate<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowDetailsTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowDetailsTemplateChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowDetailsTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowDetailsTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowDetailsTemplateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -3537,6 +5119,54 @@ public static partial class DataGridExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridRowDetailsVisibilityMode>> ObserveBindingRowDetailsVisibilityMode(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowDetailsVisibilityMode<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Controls.DataGridRowDetailsVisibilityMode>>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowDetailsVisibilityModeChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowDetailsVisibilityModeChanged<T>(this T obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.DataGrid.RowDetailsVisibilityModeProperty"/> property value to <see cref="Avalonia.Controls.DataGridRowDetailsVisibilityMode.VisibleWhenSelected"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -3612,6 +5242,52 @@ public static partial class DataGridExtensions
     public static Avalonia.Controls.DataGrid OnCollectionView(this Avalonia.Controls.DataGrid obj, Action<Avalonia.Controls.DataGrid, IObservable<Avalonia.Collections.IDataGridCollectionView>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGrid.CollectionViewProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGrid.CollectionViewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Collections.IDataGridCollectionView>> ObserveBindingCollectionView(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGrid.CollectionViewProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGrid.CollectionViewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGrid OnBindingCollectionView(this Avalonia.Controls.DataGrid obj, Action<Avalonia.Controls.DataGrid, IObservable<BindingValue<Avalonia.Collections.IDataGridCollectionView>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGrid.CollectionViewProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGrid.CollectionViewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCollectionViewChanged(this Avalonia.Controls.DataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CollectionViewProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGrid.CollectionViewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGrid OnCollectionViewChanged(this Avalonia.Controls.DataGrid obj, Action<Avalonia.Controls.DataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGrid.CollectionViewProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridCell.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridCell.Extensions.g.cs
@@ -49,4 +49,50 @@ public static partial class DataGridCellExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridCell.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsValid(this Avalonia.Controls.DataGridCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridCell.IsValidProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridCell.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGridCell OnBindingIsValid(this Avalonia.Controls.DataGridCell obj, Action<Avalonia.Controls.DataGridCell, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridCell.IsValidProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridCell.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsValidChanged(this Avalonia.Controls.DataGridCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridCell.IsValidProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridCell.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGridCell OnIsValidChanged(this Avalonia.Controls.DataGridCell obj, Action<Avalonia.Controls.DataGridCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridCell.IsValidProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DataGridCheckBoxColumn.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridCheckBoxColumn.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class DataGridCheckBoxColumnExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsThreeState(this Avalonia.Controls.DataGridCheckBoxColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsThreeState<T>(this T obj, Action<Avalonia.Controls.DataGridCheckBoxColumn, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridCheckBoxColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsThreeStateChanged(this Avalonia.Controls.DataGridCheckBoxColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsThreeStateChanged<T>(this T obj, Action<Avalonia.Controls.DataGridCheckBoxColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridCheckBoxColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridCheckBoxColumn.IsThreeStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DataGridColumn.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridColumn.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridColumnExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumn.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsVisible(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumn.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsVisible<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumn.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsVisibleChanged(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumn.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridColumn.CellThemeProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataGridColumnExtensions
     public static T OnCellTheme<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<Avalonia.Styling.ControlTheme>> handler) where T : Avalonia.Controls.DataGridColumn
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridColumn.CellThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumn.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingCellTheme(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.CellThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumn.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCellTheme<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.CellThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumn.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCellThemeChanged(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.CellThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumn.CellThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCellThemeChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.CellThemeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class DataGridColumnExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingHeader(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeader<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridColumn.HeaderTemplateProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class DataGridColumnExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingHeaderTemplate(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderTemplateChanged(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumn.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridColumn.WidthProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class DataGridColumnExtensions
     public static T OnWidth<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<Avalonia.Controls.DataGridLength>> handler) where T : Avalonia.Controls.DataGridColumn
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridColumn.WidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumn.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.DataGridLength>> ObserveBindingWidth(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.WidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumn.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWidth<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<BindingValue<Avalonia.Controls.DataGridLength>>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumn.WidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumn.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWidthChanged(this Avalonia.Controls.DataGridColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.WidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumn.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWidthChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumn.WidthProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridColumnHeader.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridColumnHeader.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridColumnHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSeparatorBrush(this Avalonia.Controls.DataGridColumnHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSeparatorBrush<T>(this T obj, Action<Avalonia.Controls.DataGridColumnHeader, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.DataGridColumnHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSeparatorBrushChanged(this Avalonia.Controls.DataGridColumnHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSeparatorBrushChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumnHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumnHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumnHeader.SeparatorBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataGridColumnHeaderExtensions
     public static T OnAreSeparatorsVisible<T>(this T obj, Action<Avalonia.Controls.DataGridColumnHeader, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.DataGridColumnHeader
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreSeparatorsVisible(this Avalonia.Controls.DataGridColumnHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreSeparatorsVisible<T>(this T obj, Action<Avalonia.Controls.DataGridColumnHeader, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridColumnHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreSeparatorsVisibleChanged(this Avalonia.Controls.DataGridColumnHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreSeparatorsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DataGridColumnHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridColumnHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridColumnHeader.AreSeparatorsVisibleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridDetailsPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridDetailsPresenter.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class DataGridDetailsPresenterExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingContentHeight(this Avalonia.Controls.Primitives.DataGridDetailsPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.DataGridDetailsPresenter OnBindingContentHeight(this Avalonia.Controls.Primitives.DataGridDetailsPresenter obj, Action<Avalonia.Controls.Primitives.DataGridDetailsPresenter, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentHeightChanged(this Avalonia.Controls.Primitives.DataGridDetailsPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.DataGridDetailsPresenter OnContentHeightChanged(this Avalonia.Controls.Primitives.DataGridDetailsPresenter obj, Action<Avalonia.Controls.Primitives.DataGridDetailsPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridDetailsPresenter.ContentHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DataGridFrozenGrid.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridFrozenGrid.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class DataGridFrozenGridExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsFrozen(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsFrozen<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsFrozenChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsFrozenChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridFrozenGrid.IsFrozenProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DataGridRow.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridRow.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRow.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingHeader(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRow.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRow.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeader<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRow.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRow.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRow.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRow.IsSelectedProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class DataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSelected(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRow.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsSelected<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRow.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSelectedChanged(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsSelectedChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRow.IsValidProperty
 
     /// <summary>
@@ -242,6 +338,52 @@ public static partial class DataGridRowExtensions
     public static Avalonia.Controls.DataGridRow OnIsValid(this Avalonia.Controls.DataGridRow obj, Action<Avalonia.Controls.DataGridRow, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridRow.IsValidProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRow.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsValid(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRow.IsValidProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRow.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGridRow OnBindingIsValid(this Avalonia.Controls.DataGridRow obj, Action<Avalonia.Controls.DataGridRow, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRow.IsValidProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRow.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsValidChanged(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.IsValidProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRow.IsValidProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.DataGridRow OnIsValidChanged(this Avalonia.Controls.DataGridRow obj, Action<Avalonia.Controls.DataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.IsValidProperty);
         handler(obj, observable);
         return obj;
     }
@@ -344,6 +486,54 @@ public static partial class DataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRow.DetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingDetailsTemplate(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRow.DetailsTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRow.DetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDetailsTemplate<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRow.DetailsTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRow.DetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDetailsTemplateChanged(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.DetailsTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRow.DetailsTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDetailsTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.DetailsTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty
 
     /// <summary>
@@ -442,6 +632,54 @@ public static partial class DataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreDetailsVisible(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreDetailsVisible<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreDetailsVisibleChanged(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreDetailsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.AreDetailsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRow.IndexProperty
 
     /// <summary>
@@ -536,6 +774,54 @@ public static partial class DataGridRowExtensions
     public static T OnIndex<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<System.Int32>> handler) where T : Avalonia.Controls.DataGridRow
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridRow.IndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRow.IndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingIndex(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRow.IndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRow.IndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIndex<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRow.IndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRow.IndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIndexChanged(this Avalonia.Controls.DataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.IndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRow.IndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIndexChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRow
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRow.IndexProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridRowGroupHeader.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridRowGroupHeader.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridRowGroupHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsItemCountVisible(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsItemCountVisible<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsItemCountVisibleChanged(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsItemCountVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.IsItemCountVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataGridRowGroupHeaderExtensions
     public static T OnItemCountFormat<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<System.String>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingItemCountFormat(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemCountFormat<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemCountFormatChanged(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemCountFormatChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.ItemCountFormatProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class DataGridRowGroupHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingPropertyName(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPropertyName<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePropertyNameChanged(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPropertyNameChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.PropertyNameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class DataGridRowGroupHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsPropertyNameVisible(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsPropertyNameVisible<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsPropertyNameVisibleChanged(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsPropertyNameVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.IsPropertyNameVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class DataGridRowGroupHeaderExtensions
     public static T OnSublevelIndent<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<System.Double>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSublevelIndent(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSublevelIndent<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSublevelIndentChanged(this Avalonia.Controls.DataGridRowGroupHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSublevelIndentChanged<T>(this T obj, Action<Avalonia.Controls.DataGridRowGroupHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridRowGroupHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridRowGroupHeader.SublevelIndentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridRowHeader.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridRowHeader.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridRowHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSeparatorBrush(this Avalonia.Controls.Primitives.DataGridRowHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSeparatorBrush<T>(this T obj, Action<Avalonia.Controls.Primitives.DataGridRowHeader, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Primitives.DataGridRowHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSeparatorBrushChanged(this Avalonia.Controls.Primitives.DataGridRowHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSeparatorBrushChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.DataGridRowHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.DataGridRowHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridRowHeader.SeparatorBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataGridRowHeaderExtensions
     public static T OnAreSeparatorsVisible<T>(this T obj, Action<Avalonia.Controls.Primitives.DataGridRowHeader, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.DataGridRowHeader
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreSeparatorsVisible(this Avalonia.Controls.Primitives.DataGridRowHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreSeparatorsVisible<T>(this T obj, Action<Avalonia.Controls.Primitives.DataGridRowHeader, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.DataGridRowHeader
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreSeparatorsVisibleChanged(this Avalonia.Controls.Primitives.DataGridRowHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreSeparatorsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.DataGridRowHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.DataGridRowHeader
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DataGridRowHeader.AreSeparatorsVisibleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridTemplateColumn.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridTemplateColumn.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridTemplateColumnExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingCellTemplate(this Avalonia.Controls.DataGridTemplateColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCellTemplate<T>(this T obj, Action<Avalonia.Controls.DataGridTemplateColumn, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.DataGridTemplateColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCellTemplateChanged(this Avalonia.Controls.DataGridTemplateColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCellTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTemplateColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTemplateColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTemplateColumn.CellTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataGridTemplateColumnExtensions
     public static T OnCellEditingTemplate<T>(this T obj, Action<Avalonia.Controls.DataGridTemplateColumn, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.DataGridTemplateColumn
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingCellEditingTemplate(this Avalonia.Controls.DataGridTemplateColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCellEditingTemplate<T>(this T obj, Action<Avalonia.Controls.DataGridTemplateColumn, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.DataGridTemplateColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCellEditingTemplateChanged(this Avalonia.Controls.DataGridTemplateColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCellEditingTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTemplateColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTemplateColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTemplateColumn.CellEditingTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataGridTextColumn.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataGridTextColumn.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataGridTextColumnExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFamily>> ObserveBindingFontFamily(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFamily<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<BindingValue<Avalonia.Media.FontFamily>>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFamilyChanged(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFamilyChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridTextColumn.FontSizeProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class DataGridTextColumnExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingFontSize(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontSize<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontSizeChanged(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontSizeChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataGridTextColumn.FontStyleProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class DataGridTextColumnExtensions
     public static T OnFontStyle<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<Avalonia.Media.FontStyle>> handler) where T : Avalonia.Controls.DataGridTextColumn
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridTextColumn.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStyle>> ObserveBindingFontStyle(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStyle<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<BindingValue<Avalonia.Media.FontStyle>>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStyleChanged(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStyleChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontStyleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -430,6 +574,54 @@ public static partial class DataGridTextColumnExtensions
     public static T OnFontWeight<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<Avalonia.Media.FontWeight>> handler) where T : Avalonia.Controls.DataGridTextColumn
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridTextColumn.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontWeight>> ObserveBindingFontWeight(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontWeight<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<BindingValue<Avalonia.Media.FontWeight>>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontWeightChanged(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontWeightChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontWeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -749,6 +941,54 @@ public static partial class DataGridTextColumnExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStretch>> ObserveBindingFontStretch(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStretch<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<BindingValue<Avalonia.Media.FontStretch>>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStretchChanged(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStretchChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.DataGridTextColumn.FontStretchProperty"/> property value to <see cref="Avalonia.Media.FontStretch.UltraCondensed"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -950,6 +1190,54 @@ public static partial class DataGridTextColumnExtensions
     public static T OnForeground<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Controls.DataGridTextColumn
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataGridTextColumn.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingForeground(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataGridTextColumn.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingForeground<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataGridTextColumn.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveForegroundChanged(this Avalonia.Controls.DataGridTextColumn obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataGridTextColumn.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnForegroundChanged<T>(this T obj, Action<Avalonia.Controls.DataGridTextColumn, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataGridTextColumn
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataGridTextColumn.ForegroundProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DataValidationErrors.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DataValidationErrors.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DataValidationErrorsExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IEnumerable<System.Object>>> ObserveBindingErrors(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.ErrorsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingErrors<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Collections.Generic.IEnumerable<System.Object>>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.ErrorsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveErrorsChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.ErrorsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnErrorsChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.ErrorsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataValidationErrors.HasErrorsProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DataValidationErrorsExtensions
     public static T OnHasErrors<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataValidationErrors.HasErrorsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.HasErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingHasErrors(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.HasErrorsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.HasErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHasErrors<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.HasErrorsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataValidationErrors.HasErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHasErrorsChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.HasErrorsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataValidationErrors.HasErrorsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHasErrorsChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.HasErrorsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class DataValidationErrorsExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Func<System.Object,System.Object>>> ObserveBindingErrorConverter(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.ErrorConverterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingErrorConverter<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Func<System.Object,System.Object>>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.ErrorConverterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveErrorConverterChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.ErrorConverterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnErrorConverterChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.ErrorConverterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class DataValidationErrorsExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingErrorTemplate(this Avalonia.Controls.DataValidationErrors obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingErrorTemplate<T>(this T obj, Action<Avalonia.Controls.DataValidationErrors, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.DataValidationErrors
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveErrorTemplateChanged(this Avalonia.Controls.DataValidationErrors obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnErrorTemplateChanged<T>(this T obj, Action<Avalonia.Controls.DataValidationErrors, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataValidationErrors
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.ErrorTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DataValidationErrors.OwnerProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class DataValidationErrorsExtensions
     public static T OnOwner<T>(this T obj, Action<Avalonia.Controls.DataValidationErrors, IObservable<Avalonia.Controls.Control>> handler) where T : Avalonia.Controls.DataValidationErrors
     {
         var observable = obj.GetObservable(Avalonia.Controls.DataValidationErrors.OwnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingOwner(this Avalonia.Controls.DataValidationErrors obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.OwnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DataValidationErrors.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOwner<T>(this T obj, Action<Avalonia.Controls.DataValidationErrors, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.DataValidationErrors
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DataValidationErrors.OwnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DataValidationErrors.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOwnerChanged(this Avalonia.Controls.DataValidationErrors obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.OwnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DataValidationErrors.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOwnerChanged<T>(this T obj, Action<Avalonia.Controls.DataValidationErrors, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DataValidationErrors
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DataValidationErrors.OwnerProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DatePicker.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DatePicker.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingDayFormat(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.DayFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDayFormat<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.DayFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDayFormatChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.DayFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDayFormatChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.DayFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePicker.DayVisibleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DatePickerExtensions
     public static T OnDayVisible<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.DatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePicker.DayVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingDayVisible(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.DayVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDayVisible<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.DayVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDayVisibleChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.DayVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDayVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.DayVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class DatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTimeOffset>> ObserveBindingMaxYear(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.MaxYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxYear<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.DateTimeOffset>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.MaxYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxYearChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MaxYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxYearChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MaxYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePicker.MinYearProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class DatePickerExtensions
     public static T OnMinYear<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<System.DateTimeOffset>> handler) where T : Avalonia.Controls.DatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePicker.MinYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTimeOffset>> ObserveBindingMinYear(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.MinYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinYear<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.DateTimeOffset>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.MinYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinYearChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MinYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinYearChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MinYearProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class DatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingMonthFormat(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.MonthFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMonthFormat<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.MonthFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMonthFormatChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MonthFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMonthFormatChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MonthFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePicker.MonthVisibleProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class DatePickerExtensions
     public static T OnMonthVisible<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.DatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePicker.MonthVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingMonthVisible(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.MonthVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMonthVisible<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.MonthVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMonthVisibleChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MonthVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMonthVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.MonthVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class DatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingYearFormat(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.YearFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingYearFormat<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.YearFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveYearFormatChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.YearFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnYearFormatChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.YearFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePicker.YearVisibleProperty
 
     /// <summary>
@@ -790,6 +1126,54 @@ public static partial class DatePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingYearVisible(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.YearVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingYearVisible<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.YearVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveYearVisibleChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.YearVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnYearVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.YearVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePicker.SelectedDateProperty
 
     /// <summary>
@@ -884,6 +1268,54 @@ public static partial class DatePickerExtensions
     public static T OnSelectedDate<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<System.Nullable<System.DateTimeOffset>>> handler) where T : Avalonia.Controls.DatePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePicker.SelectedDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.DateTimeOffset>>> ObserveBindingSelectedDate(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePicker.SelectedDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedDate<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<BindingValue<System.Nullable<System.DateTimeOffset>>>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePicker.SelectedDateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedDateChanged(this Avalonia.Controls.DatePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.SelectedDateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePicker.SelectedDateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedDateChanged<T>(this T obj, Action<Avalonia.Controls.DatePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePicker.SelectedDateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DatePickerPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DatePickerPresenter.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DatePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.DateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTimeOffset>> ObserveBindingDate(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.DateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.DateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDate<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.DateTimeOffset>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.DateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.DateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDateChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.DateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.DateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDateChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.DateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePickerPresenter.DayFormatProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DatePickerPresenterExtensions
     public static T OnDayFormat<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<System.String>> handler) where T : Avalonia.Controls.DatePickerPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePickerPresenter.DayFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingDayFormat(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.DayFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDayFormat<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.DayFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDayFormatChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.DayFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDayFormatChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.DayFormatProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class DatePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingDayVisible(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.DayVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDayVisible<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.DayVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDayVisibleChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.DayVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.DayVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDayVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.DayVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePickerPresenter.MaxYearProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class DatePickerPresenterExtensions
     public static T OnMaxYear<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<System.DateTimeOffset>> handler) where T : Avalonia.Controls.DatePickerPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePickerPresenter.MaxYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTimeOffset>> ObserveBindingMaxYear(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MaxYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxYear<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.DateTimeOffset>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MaxYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxYearChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MaxYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MaxYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxYearChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MaxYearProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class DatePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.DateTimeOffset>> ObserveBindingMinYear(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MinYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinYear<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.DateTimeOffset>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MinYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinYearChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MinYearProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MinYearProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinYearChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MinYearProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePickerPresenter.MonthFormatProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class DatePickerPresenterExtensions
     public static T OnMonthFormat<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<System.String>> handler) where T : Avalonia.Controls.DatePickerPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePickerPresenter.MonthFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingMonthFormat(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MonthFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMonthFormat<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MonthFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMonthFormatChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MonthFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMonthFormatChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MonthFormatProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class DatePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingMonthVisible(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMonthVisible<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMonthVisibleChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMonthVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.MonthVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePickerPresenter.YearFormatProperty
 
     /// <summary>
@@ -790,6 +1126,54 @@ public static partial class DatePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingYearFormat(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.YearFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingYearFormat<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.YearFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveYearFormatChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.YearFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnYearFormatChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.YearFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DatePickerPresenter.YearVisibleProperty
 
     /// <summary>
@@ -884,6 +1268,54 @@ public static partial class DatePickerPresenterExtensions
     public static T OnYearVisible<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.DatePickerPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.DatePickerPresenter.YearVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingYearVisible(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.YearVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingYearVisible<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DatePickerPresenter.YearVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveYearVisibleChanged(this Avalonia.Controls.DatePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.YearVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DatePickerPresenter.YearVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnYearVisibleChanged<T>(this T obj, Action<Avalonia.Controls.DatePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DatePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DatePickerPresenter.YearVisibleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DateTimePickerPanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DateTimePickerPanel.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DateTimePickerPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingItemHeight(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemHeight<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemHeightChanged(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemHeightChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DateTimePickerPanelExtensions
     public static T OnPanelType<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<Avalonia.Controls.Primitives.DateTimePickerPanelType>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.DateTimePickerPanelType>> ObserveBindingPanelType(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPanelType<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<BindingValue<Avalonia.Controls.Primitives.DateTimePickerPanelType>>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePanelTypeChanged(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPanelTypeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.PanelTypeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -384,6 +480,54 @@ public static partial class DateTimePickerPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingItemFormat(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemFormat<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemFormatChanged(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemFormatChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ItemFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty
 
     /// <summary>
@@ -478,6 +622,54 @@ public static partial class DateTimePickerPanelExtensions
     public static T OnShouldLoop<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShouldLoop(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShouldLoop<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShouldLoopChanged(this Avalonia.Controls.Primitives.DateTimePickerPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShouldLoopChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.DateTimePickerPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.DateTimePickerPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.DateTimePickerPanel.ShouldLoopProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Decorator.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Decorator.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DecoratorExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Decorator.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingChild(this Avalonia.Controls.Decorator obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Decorator.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Decorator.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingChild<T>(this T obj, Action<Avalonia.Controls.Decorator, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.Decorator
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Decorator.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Decorator.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildChanged(this Avalonia.Controls.Decorator obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Decorator.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Decorator.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnChildChanged<T>(this T obj, Action<Avalonia.Controls.Decorator, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Decorator
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Decorator.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Decorator.PaddingProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class DecoratorExtensions
     public static T OnPadding<T>(this T obj, Action<Avalonia.Controls.Decorator, IObservable<Avalonia.Thickness>> handler) where T : Avalonia.Controls.Decorator
     {
         var observable = obj.GetObservable(Avalonia.Controls.Decorator.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Decorator.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingPadding(this Avalonia.Controls.Decorator obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Decorator.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Decorator.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPadding<T>(this T obj, Action<Avalonia.Controls.Decorator, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.Decorator
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Decorator.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Decorator.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaddingChanged(this Avalonia.Controls.Decorator obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Decorator.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Decorator.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaddingChanged<T>(this T obj, Action<Avalonia.Controls.Decorator, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Decorator
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Decorator.PaddingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DefinitionBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DefinitionBase.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class DefinitionBaseExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingSharedSizeGroup(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSharedSizeGroup<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSharedSizeGroupChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSharedSizeGroupChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DefinitionBase.SharedSizeGroupProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DockPanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DockPanel.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class DockPanelExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DockPanel.DockProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Dock>> ObserveBindingDock(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DockPanel.DockProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DockPanel.DockProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDock<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Dock>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DockPanel.DockProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DockPanel.DockProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDockChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.DockProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DockPanel.DockProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDockChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.DockProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.DockPanel.DockProperty"/> property value to <see cref="Avalonia.Controls.Dock.Left"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -250,6 +298,54 @@ public static partial class DockPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DockPanel.LastChildFillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingLastChildFill(this Avalonia.Controls.DockPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DockPanel.LastChildFillProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DockPanel.LastChildFillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLastChildFill<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.DockPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DockPanel.LastChildFillProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DockPanel.LastChildFillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLastChildFillChanged(this Avalonia.Controls.DockPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.LastChildFillProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DockPanel.LastChildFillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLastChildFillChanged<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DockPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.LastChildFillProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DockPanel.HorizontalSpacingProperty
 
     /// <summary>
@@ -348,6 +444,54 @@ public static partial class DockPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DockPanel.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalSpacing(this Avalonia.Controls.DockPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DockPanel.HorizontalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DockPanel.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalSpacing<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DockPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DockPanel.HorizontalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DockPanel.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalSpacingChanged(this Avalonia.Controls.DockPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.HorizontalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DockPanel.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalSpacingChanged<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DockPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.HorizontalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.DockPanel.VerticalSpacingProperty
 
     /// <summary>
@@ -442,6 +586,54 @@ public static partial class DockPanelExtensions
     public static T OnVerticalSpacing<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<System.Double>> handler) where T : Avalonia.Controls.DockPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.DockPanel.VerticalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.DockPanel.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalSpacing(this Avalonia.Controls.DockPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.DockPanel.VerticalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.DockPanel.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalSpacing<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.DockPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.DockPanel.VerticalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.DockPanel.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalSpacingChanged(this Avalonia.Controls.DockPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.VerticalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.DockPanel.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalSpacingChanged<T>(this T obj, Action<Avalonia.Controls.DockPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.DockPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.DockPanel.VerticalSpacingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DrawingBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DrawingBrush.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class DrawingBrushExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingBrush.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Drawing>> ObserveBindingDrawing(this Avalonia.Media.DrawingBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingBrush.DrawingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingBrush.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingBrush OnBindingDrawing(this Avalonia.Media.DrawingBrush obj, Action<Avalonia.Media.DrawingBrush, IObservable<BindingValue<Avalonia.Media.Drawing>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingBrush.DrawingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingBrush.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDrawingChanged(this Avalonia.Media.DrawingBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingBrush.DrawingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingBrush.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingBrush OnDrawingChanged(this Avalonia.Media.DrawingBrush obj, Action<Avalonia.Media.DrawingBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingBrush.DrawingProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DrawingGroup.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DrawingGroup.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class DrawingGroupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingGroup.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOpacity(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingGroup.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingGroup.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnBindingOpacity(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingGroup.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingGroup.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpacityChanged(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingGroup.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnOpacityChanged(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DrawingGroup.TransformProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class DrawingGroupExtensions
     public static Avalonia.Media.DrawingGroup OnTransform(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<Avalonia.Media.Transform>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.DrawingGroup.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingGroup.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Transform>> ObserveBindingTransform(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingGroup.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingGroup.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnBindingTransform(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<BindingValue<Avalonia.Media.Transform>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingGroup.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingGroup.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransformChanged(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingGroup.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnTransformChanged(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.TransformProperty);
         handler(obj, observable);
         return obj;
     }
@@ -285,6 +377,52 @@ public static partial class DrawingGroupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingGroup.ClipGeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingClipGeometry(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingGroup.ClipGeometryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingGroup.ClipGeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnBindingClipGeometry(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingGroup.ClipGeometryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingGroup.ClipGeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClipGeometryChanged(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.ClipGeometryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingGroup.ClipGeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnClipGeometryChanged(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.ClipGeometryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DrawingGroup.OpacityMaskProperty
 
     /// <summary>
@@ -378,6 +516,52 @@ public static partial class DrawingGroupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingGroup.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingOpacityMask(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingGroup.OpacityMaskProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingGroup.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnBindingOpacityMask(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingGroup.OpacityMaskProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingGroup.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpacityMaskChanged(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.OpacityMaskProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingGroup.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnOpacityMaskChanged(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.OpacityMaskProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DrawingGroup.ChildrenProperty
 
     /// <summary>
@@ -467,6 +651,52 @@ public static partial class DrawingGroupExtensions
     public static Avalonia.Media.DrawingGroup OnChildren(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<Avalonia.Media.DrawingCollection>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.DrawingGroup.ChildrenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.DrawingCollection>> ObserveBindingChildren(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingGroup.ChildrenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnBindingChildren(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<BindingValue<Avalonia.Media.DrawingCollection>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingGroup.ChildrenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildrenChanged(this Avalonia.Media.DrawingGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.ChildrenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DrawingGroup OnChildrenChanged(this Avalonia.Media.DrawingGroup obj, Action<Avalonia.Media.DrawingGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingGroup.ChildrenProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DrawingImage.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DrawingImage.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class DrawingImageExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DrawingImage.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Drawing>> ObserveBindingDrawing(this Avalonia.Media.DrawingImage obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DrawingImage.DrawingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DrawingImage.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDrawing<T>(this T obj, Action<Avalonia.Media.DrawingImage, IObservable<BindingValue<Avalonia.Media.Drawing>>> handler) where T : Avalonia.Media.DrawingImage
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DrawingImage.DrawingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DrawingImage.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDrawingChanged(this Avalonia.Media.DrawingImage obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DrawingImage.DrawingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DrawingImage.DrawingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDrawingChanged<T>(this T obj, Action<Avalonia.Media.DrawingImage, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.DrawingImage
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DrawingImage.DrawingProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/DropShadowDirectionEffect.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DropShadowDirectionEffect.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class DropShadowDirectionEffectExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingShadowDepth(this Avalonia.Media.DropShadowDirectionEffect obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowDirectionEffect OnBindingShadowDepth(this Avalonia.Media.DropShadowDirectionEffect obj, Action<Avalonia.Media.DropShadowDirectionEffect, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShadowDepthChanged(this Avalonia.Media.DropShadowDirectionEffect obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowDirectionEffect OnShadowDepthChanged(this Avalonia.Media.DropShadowDirectionEffect obj, Action<Avalonia.Media.DropShadowDirectionEffect, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowDirectionEffect.ShadowDepthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DropShadowDirectionEffect.DirectionProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class DropShadowDirectionEffectExtensions
     public static Avalonia.Media.DropShadowDirectionEffect OnDirection(this Avalonia.Media.DropShadowDirectionEffect obj, Action<Avalonia.Media.DropShadowDirectionEffect, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.DropShadowDirectionEffect.DirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.DirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingDirection(this Avalonia.Media.DropShadowDirectionEffect obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowDirectionEffect.DirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.DirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowDirectionEffect OnBindingDirection(this Avalonia.Media.DropShadowDirectionEffect obj, Action<Avalonia.Media.DropShadowDirectionEffect, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowDirectionEffect.DirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.DirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDirectionChanged(this Avalonia.Media.DropShadowDirectionEffect obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowDirectionEffect.DirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowDirectionEffect.DirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowDirectionEffect OnDirectionChanged(this Avalonia.Media.DropShadowDirectionEffect obj, Action<Avalonia.Media.DropShadowDirectionEffect, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowDirectionEffect.DirectionProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DropShadowEffect.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DropShadowEffect.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class DropShadowEffectExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOffsetX(this Avalonia.Media.DropShadowEffect obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowEffect.OffsetXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowEffect OnBindingOffsetX(this Avalonia.Media.DropShadowEffect obj, Action<Avalonia.Media.DropShadowEffect, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowEffect.OffsetXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffsetXChanged(this Avalonia.Media.DropShadowEffect obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffect.OffsetXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowEffect OnOffsetXChanged(this Avalonia.Media.DropShadowEffect obj, Action<Avalonia.Media.DropShadowEffect, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffect.OffsetXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DropShadowEffect.OffsetYProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class DropShadowEffectExtensions
     public static Avalonia.Media.DropShadowEffect OnOffsetY(this Avalonia.Media.DropShadowEffect obj, Action<Avalonia.Media.DropShadowEffect, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.DropShadowEffect.OffsetYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOffsetY(this Avalonia.Media.DropShadowEffect obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowEffect.OffsetYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowEffect OnBindingOffsetY(this Avalonia.Media.DropShadowEffect obj, Action<Avalonia.Media.DropShadowEffect, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowEffect.OffsetYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffsetYChanged(this Avalonia.Media.DropShadowEffect obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffect.OffsetYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowEffect.OffsetYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.DropShadowEffect OnOffsetYChanged(this Avalonia.Media.DropShadowEffect obj, Action<Avalonia.Media.DropShadowEffect, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffect.OffsetYProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/DropShadowEffectBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/DropShadowEffectBase.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class DropShadowEffectBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingBlurRadius(this Avalonia.Media.DropShadowEffectBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBlurRadius<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.DropShadowEffectBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBlurRadiusChanged(this Avalonia.Media.DropShadowEffectBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBlurRadiusChanged<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.DropShadowEffectBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffectBase.BlurRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DropShadowEffectBase.ColorProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class DropShadowEffectBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowEffectBase.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingColor(this Avalonia.Media.DropShadowEffectBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowEffectBase.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowEffectBase.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColor<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<BindingValue<Avalonia.Media.Color>>> handler) where T : Avalonia.Media.DropShadowEffectBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowEffectBase.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowEffectBase.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorChanged(this Avalonia.Media.DropShadowEffectBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffectBase.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowEffectBase.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColorChanged<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.DropShadowEffectBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffectBase.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.DropShadowEffectBase.OpacityProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class DropShadowEffectBaseExtensions
     public static T OnOpacity<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<System.Double>> handler) where T : Avalonia.Media.DropShadowEffectBase
     {
         var observable = obj.GetObservable(Avalonia.Media.DropShadowEffectBase.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.DropShadowEffectBase.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOpacity(this Avalonia.Media.DropShadowEffectBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.DropShadowEffectBase.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.DropShadowEffectBase.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOpacity<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.DropShadowEffectBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.DropShadowEffectBase.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.DropShadowEffectBase.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpacityChanged(this Avalonia.Media.DropShadowEffectBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffectBase.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.DropShadowEffectBase.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOpacityChanged<T>(this T obj, Action<Avalonia.Media.DropShadowEffectBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.DropShadowEffectBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.DropShadowEffectBase.OpacityProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/EllipseGeometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/EllipseGeometry.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class EllipseGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.EllipseGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Rect>> ObserveBindingRect(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.RectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.EllipseGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRect<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<BindingValue<Avalonia.Rect>>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.RectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.EllipseGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRectChanged(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.RectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.EllipseGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRectChanged<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.RectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.EllipseGeometry.RadiusXProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class EllipseGeometryExtensions
     public static T OnRadiusX<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<System.Double>> handler) where T : Avalonia.Media.EllipseGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.EllipseGeometry.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadiusX(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRadiusX<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusXChanged(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRadiusXChanged<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.RadiusXProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class EllipseGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadiusY(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRadiusY<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusYChanged(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.EllipseGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRadiusYChanged<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.EllipseGeometry.CenterProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class EllipseGeometryExtensions
     public static T OnCenter<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<Avalonia.Point>> handler) where T : Avalonia.Media.EllipseGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.EllipseGeometry.CenterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.EllipseGeometry.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingCenter(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.CenterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.EllipseGeometry.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCenter<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<BindingValue<Avalonia.Point>>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.EllipseGeometry.CenterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.EllipseGeometry.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterChanged(this Avalonia.Media.EllipseGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.CenterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.EllipseGeometry.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCenterChanged<T>(this T obj, Action<Avalonia.Media.EllipseGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.EllipseGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.EllipseGeometry.CenterProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Expander.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Expander.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ExpanderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Expander.ContentTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.IPageTransition>> ObserveBindingContentTransition(this Avalonia.Controls.Expander obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Expander.ContentTransitionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Expander.ContentTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContentTransition<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<BindingValue<Avalonia.Animation.IPageTransition>>> handler) where T : Avalonia.Controls.Expander
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Expander.ContentTransitionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Expander.ContentTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTransitionChanged(this Avalonia.Controls.Expander obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Expander.ContentTransitionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Expander.ContentTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentTransitionChanged<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Expander
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Expander.ContentTransitionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Expander.ExpandDirectionProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ExpanderExtensions
     public static T OnExpandDirection<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<Avalonia.Controls.ExpandDirection>> handler) where T : Avalonia.Controls.Expander
     {
         var observable = obj.GetObservable(Avalonia.Controls.Expander.ExpandDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Expander.ExpandDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ExpandDirection>> ObserveBindingExpandDirection(this Avalonia.Controls.Expander obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Expander.ExpandDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Expander.ExpandDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingExpandDirection<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<BindingValue<Avalonia.Controls.ExpandDirection>>> handler) where T : Avalonia.Controls.Expander
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Expander.ExpandDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Expander.ExpandDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveExpandDirectionChanged(this Avalonia.Controls.Expander obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Expander.ExpandDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Expander.ExpandDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnExpandDirectionChanged<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Expander
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Expander.ExpandDirectionProperty);
         handler(obj, observable);
         return obj;
     }
@@ -344,6 +440,54 @@ public static partial class ExpanderExtensions
     public static T OnIsExpanded<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Expander
     {
         var observable = obj.GetObservable(Avalonia.Controls.Expander.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Expander.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsExpanded(this Avalonia.Controls.Expander obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Expander.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Expander.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsExpanded<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Expander
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Expander.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Expander.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsExpandedChanged(this Avalonia.Controls.Expander obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Expander.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Expander.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsExpandedChanged<T>(this T obj, Action<Avalonia.Controls.Expander, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Expander
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Expander.IsExpandedProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ExperimentalAcrylicBorder.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ExperimentalAcrylicBorder.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ExperimentalAcrylicBorderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.CornerRadius>> ObserveBindingCornerRadius(this Avalonia.Controls.ExperimentalAcrylicBorder obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCornerRadius<T>(this T obj, Action<Avalonia.Controls.ExperimentalAcrylicBorder, IObservable<BindingValue<Avalonia.CornerRadius>>> handler) where T : Avalonia.Controls.ExperimentalAcrylicBorder
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCornerRadiusChanged(this Avalonia.Controls.ExperimentalAcrylicBorder obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCornerRadiusChanged<T>(this T obj, Action<Avalonia.Controls.ExperimentalAcrylicBorder, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ExperimentalAcrylicBorder
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ExperimentalAcrylicBorder.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ExperimentalAcrylicBorderExtensions
     public static T OnMaterial<T>(this T obj, Action<Avalonia.Controls.ExperimentalAcrylicBorder, IObservable<Avalonia.Media.ExperimentalAcrylicMaterial>> handler) where T : Avalonia.Controls.ExperimentalAcrylicBorder
     {
         var observable = obj.GetObservable(Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.ExperimentalAcrylicMaterial>> ObserveBindingMaterial(this Avalonia.Controls.ExperimentalAcrylicBorder obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaterial<T>(this T obj, Action<Avalonia.Controls.ExperimentalAcrylicBorder, IObservable<BindingValue<Avalonia.Media.ExperimentalAcrylicMaterial>>> handler) where T : Avalonia.Controls.ExperimentalAcrylicBorder
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaterialChanged(this Avalonia.Controls.ExperimentalAcrylicBorder obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaterialChanged<T>(this T obj, Action<Avalonia.Controls.ExperimentalAcrylicBorder, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ExperimentalAcrylicBorder
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ExperimentalAcrylicBorder.MaterialProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ExperimentalAcrylicMaterial.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ExperimentalAcrylicMaterial.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ExperimentalAcrylicMaterialExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingTintColor(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTintColor<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<BindingValue<Avalonia.Media.Color>>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTintColorChanged(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTintColorChanged<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ExperimentalAcrylicMaterialExtensions
     public static T OnBackgroundSource<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<Avalonia.Media.AcrylicBackgroundSource>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
     {
         var observable = obj.GetObservable(Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.AcrylicBackgroundSource>> ObserveBindingBackgroundSource(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackgroundSource<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<BindingValue<Avalonia.Media.AcrylicBackgroundSource>>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundSourceChanged(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundSourceChanged<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.BackgroundSourceProperty);
         handler(obj, observable);
         return obj;
     }
@@ -324,6 +420,54 @@ public static partial class ExperimentalAcrylicMaterialExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingTintOpacity(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTintOpacity<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTintOpacityChanged(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTintOpacityChanged<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.TintOpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty
 
     /// <summary>
@@ -418,6 +562,54 @@ public static partial class ExperimentalAcrylicMaterialExtensions
     public static T OnMaterialOpacity<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<System.Double>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
     {
         var observable = obj.GetObservable(Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaterialOpacity(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaterialOpacity<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaterialOpacityChanged(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaterialOpacityChanged<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.MaterialOpacityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -520,6 +712,54 @@ public static partial class ExperimentalAcrylicMaterialExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingPlatformTransparencyCompensationLevel(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlatformTransparencyCompensationLevel<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlatformTransparencyCompensationLevelChanged(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlatformTransparencyCompensationLevelChanged<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.PlatformTransparencyCompensationLevelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty
 
     /// <summary>
@@ -614,6 +854,54 @@ public static partial class ExperimentalAcrylicMaterialExtensions
     public static T OnFallbackColor<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<Avalonia.Media.Color>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
     {
         var observable = obj.GetObservable(Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingFallbackColor(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFallbackColor<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<BindingValue<Avalonia.Media.Color>>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFallbackColorChanged(this Avalonia.Media.ExperimentalAcrylicMaterial obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFallbackColorChanged<T>(this T obj, Action<Avalonia.Media.ExperimentalAcrylicMaterial, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.ExperimentalAcrylicMaterial
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ExperimentalAcrylicMaterial.FallbackColorProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Flyout.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Flyout.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class FlyoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Flyout.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingContent(this Avalonia.Controls.Flyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Flyout.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Flyout.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContent<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Flyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Flyout.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Flyout.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentChanged(this Avalonia.Controls.Flyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Flyout.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Flyout.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentChanged<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Flyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Flyout.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Flyout.ContentTemplateProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class FlyoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Flyout.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingContentTemplate(this Avalonia.Controls.Flyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Flyout.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Flyout.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContentTemplate<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.Flyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Flyout.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Flyout.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTemplateChanged(this Avalonia.Controls.Flyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Flyout.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Flyout.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Flyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Flyout.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class FlyoutExtensions
     public static T OnFlyoutPresenterTheme<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<Avalonia.Styling.ControlTheme>> handler) where T : Avalonia.Controls.Flyout
     {
         var observable = obj.GetObservable(Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingFlyoutPresenterTheme(this Avalonia.Controls.Flyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFlyoutPresenterTheme<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.Flyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFlyoutPresenterThemeChanged(this Avalonia.Controls.Flyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFlyoutPresenterThemeChanged<T>(this T obj, Action<Avalonia.Controls.Flyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Flyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Flyout.FlyoutPresenterThemeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/FlyoutBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/FlyoutBase.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class FlyoutBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsOpen(this Avalonia.Controls.Primitives.FlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.FlyoutBase OnBindingIsOpen(this Avalonia.Controls.Primitives.FlyoutBase obj, Action<Avalonia.Controls.Primitives.FlyoutBase, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsOpenChanged(this Avalonia.Controls.Primitives.FlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.FlyoutBase OnIsOpenChanged(this Avalonia.Controls.Primitives.FlyoutBase obj, Action<Avalonia.Controls.Primitives.FlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.FlyoutBase.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.FlyoutBase.TargetProperty
 
     /// <summary>
@@ -90,6 +136,52 @@ public static partial class FlyoutBaseExtensions
     public static Avalonia.Controls.Primitives.FlyoutBase OnTarget(this Avalonia.Controls.Primitives.FlyoutBase obj, Action<Avalonia.Controls.Primitives.FlyoutBase, IObservable<Avalonia.Controls.Control>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.FlyoutBase.TargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingTarget(this Avalonia.Controls.Primitives.FlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.FlyoutBase.TargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.FlyoutBase OnBindingTarget(this Avalonia.Controls.Primitives.FlyoutBase obj, Action<Avalonia.Controls.Primitives.FlyoutBase, IObservable<BindingValue<Avalonia.Controls.Control>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.FlyoutBase.TargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTargetChanged(this Avalonia.Controls.Primitives.FlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.FlyoutBase.TargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.FlyoutBase OnTargetChanged(this Avalonia.Controls.Primitives.FlyoutBase obj, Action<Avalonia.Controls.Primitives.FlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.FlyoutBase.TargetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -188,6 +280,54 @@ public static partial class FlyoutBaseExtensions
     public static T OnAttachedFlyout<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Controls.Primitives.FlyoutBase>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>> ObserveBindingAttachedFlyout(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAttachedFlyout<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAttachedFlyoutChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAttachedFlyoutChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Geometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Geometry.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class GeometryExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Geometry.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Transform>> ObserveBindingTransform(this Avalonia.Media.Geometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Geometry.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Geometry.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransform<T>(this T obj, Action<Avalonia.Media.Geometry, IObservable<BindingValue<Avalonia.Media.Transform>>> handler) where T : Avalonia.Media.Geometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Geometry.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Geometry.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransformChanged(this Avalonia.Media.Geometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Geometry.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Geometry.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransformChanged<T>(this T obj, Action<Avalonia.Media.Geometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.Geometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Geometry.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/GeometryDrawing.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/GeometryDrawing.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class GeometryDrawingExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GeometryDrawing.GeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingGeometry(this Avalonia.Media.GeometryDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GeometryDrawing.GeometryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GeometryDrawing.GeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GeometryDrawing OnBindingGeometry(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GeometryDrawing.GeometryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GeometryDrawing.GeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGeometryChanged(this Avalonia.Media.GeometryDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GeometryDrawing.GeometryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GeometryDrawing.GeometryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GeometryDrawing OnGeometryChanged(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GeometryDrawing.GeometryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.GeometryDrawing.BrushProperty
 
     /// <summary>
@@ -192,6 +238,52 @@ public static partial class GeometryDrawingExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GeometryDrawing.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBrush(this Avalonia.Media.GeometryDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GeometryDrawing.BrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GeometryDrawing.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GeometryDrawing OnBindingBrush(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GeometryDrawing.BrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GeometryDrawing.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBrushChanged(this Avalonia.Media.GeometryDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GeometryDrawing.BrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GeometryDrawing.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GeometryDrawing OnBrushChanged(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GeometryDrawing.BrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.GeometryDrawing.PenProperty
 
     /// <summary>
@@ -281,6 +373,52 @@ public static partial class GeometryDrawingExtensions
     public static Avalonia.Media.GeometryDrawing OnPen(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<Avalonia.Media.IPen>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.GeometryDrawing.PenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GeometryDrawing.PenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IPen>> ObserveBindingPen(this Avalonia.Media.GeometryDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GeometryDrawing.PenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GeometryDrawing.PenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GeometryDrawing OnBindingPen(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<BindingValue<Avalonia.Media.IPen>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GeometryDrawing.PenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GeometryDrawing.PenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePenChanged(this Avalonia.Media.GeometryDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GeometryDrawing.PenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GeometryDrawing.PenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GeometryDrawing OnPenChanged(this Avalonia.Media.GeometryDrawing obj, Action<Avalonia.Media.GeometryDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GeometryDrawing.PenProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/GeometryGroup.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/GeometryGroup.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class GeometryGroupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GeometryGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.GeometryCollection>> ObserveBindingChildren(this Avalonia.Media.GeometryGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GeometryGroup.ChildrenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GeometryGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingChildren<T>(this T obj, Action<Avalonia.Media.GeometryGroup, IObservable<BindingValue<Avalonia.Media.GeometryCollection>>> handler) where T : Avalonia.Media.GeometryGroup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GeometryGroup.ChildrenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GeometryGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildrenChanged(this Avalonia.Media.GeometryGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GeometryGroup.ChildrenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GeometryGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnChildrenChanged<T>(this T obj, Action<Avalonia.Media.GeometryGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.GeometryGroup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GeometryGroup.ChildrenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.GeometryGroup.FillRuleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class GeometryGroupExtensions
     public static T OnFillRule<T>(this T obj, Action<Avalonia.Media.GeometryGroup, IObservable<Avalonia.Media.FillRule>> handler) where T : Avalonia.Media.GeometryGroup
     {
         var observable = obj.GetObservable(Avalonia.Media.GeometryGroup.FillRuleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GeometryGroup.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FillRule>> ObserveBindingFillRule(this Avalonia.Media.GeometryGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GeometryGroup.FillRuleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GeometryGroup.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFillRule<T>(this T obj, Action<Avalonia.Media.GeometryGroup, IObservable<BindingValue<Avalonia.Media.FillRule>>> handler) where T : Avalonia.Media.GeometryGroup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GeometryGroup.FillRuleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GeometryGroup.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFillRuleChanged(this Avalonia.Media.GeometryGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GeometryGroup.FillRuleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GeometryGroup.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFillRuleChanged<T>(this T obj, Action<Avalonia.Media.GeometryGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.GeometryGroup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GeometryGroup.FillRuleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/GlyphRunDrawing.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/GlyphRunDrawing.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class GlyphRunDrawingExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GlyphRunDrawing.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingForeground(this Avalonia.Media.GlyphRunDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GlyphRunDrawing.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GlyphRunDrawing.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GlyphRunDrawing OnBindingForeground(this Avalonia.Media.GlyphRunDrawing obj, Action<Avalonia.Media.GlyphRunDrawing, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GlyphRunDrawing.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GlyphRunDrawing.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveForegroundChanged(this Avalonia.Media.GlyphRunDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GlyphRunDrawing.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GlyphRunDrawing.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GlyphRunDrawing OnForegroundChanged(this Avalonia.Media.GlyphRunDrawing obj, Action<Avalonia.Media.GlyphRunDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GlyphRunDrawing.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.GlyphRunDrawing.GlyphRunProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class GlyphRunDrawingExtensions
     public static Avalonia.Media.GlyphRunDrawing OnGlyphRun(this Avalonia.Media.GlyphRunDrawing obj, Action<Avalonia.Media.GlyphRunDrawing, IObservable<Avalonia.Media.GlyphRun>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.GlyphRunDrawing.GlyphRunProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GlyphRunDrawing.GlyphRunProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.GlyphRun>> ObserveBindingGlyphRun(this Avalonia.Media.GlyphRunDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GlyphRunDrawing.GlyphRunProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GlyphRunDrawing.GlyphRunProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GlyphRunDrawing OnBindingGlyphRun(this Avalonia.Media.GlyphRunDrawing obj, Action<Avalonia.Media.GlyphRunDrawing, IObservable<BindingValue<Avalonia.Media.GlyphRun>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GlyphRunDrawing.GlyphRunProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GlyphRunDrawing.GlyphRunProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGlyphRunChanged(this Avalonia.Media.GlyphRunDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GlyphRunDrawing.GlyphRunProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GlyphRunDrawing.GlyphRunProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GlyphRunDrawing OnGlyphRunChanged(this Avalonia.Media.GlyphRunDrawing obj, Action<Avalonia.Media.GlyphRunDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GlyphRunDrawing.GlyphRunProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/GradientBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/GradientBrush.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class GradientBrushExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GradientBrush.SpreadMethodProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.GradientSpreadMethod>> ObserveBindingSpreadMethod(this Avalonia.Media.GradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GradientBrush.SpreadMethodProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GradientBrush.SpreadMethodProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSpreadMethod<T>(this T obj, Action<Avalonia.Media.GradientBrush, IObservable<BindingValue<Avalonia.Media.GradientSpreadMethod>>> handler) where T : Avalonia.Media.GradientBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GradientBrush.SpreadMethodProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GradientBrush.SpreadMethodProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSpreadMethodChanged(this Avalonia.Media.GradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GradientBrush.SpreadMethodProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GradientBrush.SpreadMethodProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSpreadMethodChanged<T>(this T obj, Action<Avalonia.Media.GradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.GradientBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GradientBrush.SpreadMethodProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Media.GradientBrush.SpreadMethodProperty"/> property value to <see cref="Avalonia.Media.GradientSpreadMethod.Pad"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -234,6 +282,54 @@ public static partial class GradientBrushExtensions
     public static T OnGradientStops<T>(this T obj, Action<Avalonia.Media.GradientBrush, IObservable<Avalonia.Media.GradientStops>> handler) where T : Avalonia.Media.GradientBrush
     {
         var observable = obj.GetObservable(Avalonia.Media.GradientBrush.GradientStopsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GradientBrush.GradientStopsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.GradientStops>> ObserveBindingGradientStops(this Avalonia.Media.GradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GradientBrush.GradientStopsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GradientBrush.GradientStopsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGradientStops<T>(this T obj, Action<Avalonia.Media.GradientBrush, IObservable<BindingValue<Avalonia.Media.GradientStops>>> handler) where T : Avalonia.Media.GradientBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GradientBrush.GradientStopsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GradientBrush.GradientStopsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGradientStopsChanged(this Avalonia.Media.GradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GradientBrush.GradientStopsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GradientBrush.GradientStopsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGradientStopsChanged<T>(this T obj, Action<Avalonia.Media.GradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.GradientBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GradientBrush.GradientStopsProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/GradientStop.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/GradientStop.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class GradientStopExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GradientStop.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOffset(this Avalonia.Media.GradientStop obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GradientStop.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GradientStop.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GradientStop OnBindingOffset(this Avalonia.Media.GradientStop obj, Action<Avalonia.Media.GradientStop, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GradientStop.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GradientStop.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffsetChanged(this Avalonia.Media.GradientStop obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GradientStop.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GradientStop.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GradientStop OnOffsetChanged(this Avalonia.Media.GradientStop obj, Action<Avalonia.Media.GradientStop, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GradientStop.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.GradientStop.ColorProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class GradientStopExtensions
     public static Avalonia.Media.GradientStop OnColor(this Avalonia.Media.GradientStop obj, Action<Avalonia.Media.GradientStop, IObservable<Avalonia.Media.Color>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.GradientStop.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.GradientStop.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingColor(this Avalonia.Media.GradientStop obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.GradientStop.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.GradientStop.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GradientStop OnBindingColor(this Avalonia.Media.GradientStop obj, Action<Avalonia.Media.GradientStop, IObservable<BindingValue<Avalonia.Media.Color>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.GradientStop.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.GradientStop.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorChanged(this Avalonia.Media.GradientStop obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.GradientStop.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.GradientStop.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.GradientStop OnColorChanged(this Avalonia.Media.GradientStop obj, Action<Avalonia.Media.GradientStop, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.GradientStop.ColorProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Grid.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Grid.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class GridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.ShowGridLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowGridLines(this Avalonia.Controls.Grid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.ShowGridLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.ShowGridLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowGridLines<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Grid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.ShowGridLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.ShowGridLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowGridLinesChanged(this Avalonia.Controls.Grid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ShowGridLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.ShowGridLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowGridLinesChanged<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Grid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ShowGridLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Grid.RowSpacingProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class GridExtensions
     public static T OnRowSpacing<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<System.Double>> handler) where T : Avalonia.Controls.Grid
     {
         var observable = obj.GetObservable(Avalonia.Controls.Grid.RowSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRowSpacing(this Avalonia.Controls.Grid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.RowSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowSpacing<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Grid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.RowSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowSpacingChanged(this Avalonia.Controls.Grid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.RowSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowSpacingChanged<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Grid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.RowSpacingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class GridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingColumnSpacing(this Avalonia.Controls.Grid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.ColumnSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumnSpacing<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Grid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.ColumnSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnSpacingChanged(this Avalonia.Controls.Grid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ColumnSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnSpacingChanged<T>(this T obj, Action<Avalonia.Controls.Grid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Grid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ColumnSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Grid.ColumnProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class GridExtensions
     public static T OnColumn<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Grid.ColumnProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.ColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingColumn(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.ColumnProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.ColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumn<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.ColumnProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.ColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ColumnProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.ColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ColumnProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class GridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.RowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingRow(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.RowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.RowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRow<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.RowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.RowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.RowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.RowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.RowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Grid.ColumnSpanProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class GridExtensions
     public static T OnColumnSpan<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Grid.ColumnSpanProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.ColumnSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingColumnSpan(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.ColumnSpanProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.ColumnSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumnSpan<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.ColumnSpanProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.ColumnSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnSpanChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ColumnSpanProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.ColumnSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnSpanChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.ColumnSpanProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class GridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.RowSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingRowSpan(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.RowSpanProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.RowSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowSpan<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.RowSpanProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.RowSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowSpanChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.RowSpanProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.RowSpanProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowSpanChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.RowSpanProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Grid.IsSharedSizeScopeProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class GridExtensions
     public static T OnIsSharedSizeScope<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Grid.IsSharedSizeScopeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Grid.IsSharedSizeScopeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSharedSizeScope(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Grid.IsSharedSizeScopeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Grid.IsSharedSizeScopeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsSharedSizeScope<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Grid.IsSharedSizeScopeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Grid.IsSharedSizeScopeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSharedSizeScopeChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.IsSharedSizeScopeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Grid.IsSharedSizeScopeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsSharedSizeScopeChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Grid.IsSharedSizeScopeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/GridSplitter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/GridSplitter.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class GridSplitterExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.GridSplitter.ResizeDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.GridResizeDirection>> ObserveBindingResizeDirection(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.GridSplitter.ResizeDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.GridSplitter.ResizeDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingResizeDirection<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<BindingValue<Avalonia.Controls.GridResizeDirection>>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.GridSplitter.ResizeDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.GridSplitter.ResizeDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveResizeDirectionChanged(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.ResizeDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.GridSplitter.ResizeDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnResizeDirectionChanged<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.ResizeDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.GridSplitter.ResizeDirectionProperty"/> property value to <see cref="Avalonia.Controls.GridResizeDirection.Auto"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -234,6 +282,54 @@ public static partial class GridSplitterExtensions
     public static T OnResizeBehavior<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<Avalonia.Controls.GridResizeBehavior>> handler) where T : Avalonia.Controls.GridSplitter
     {
         var observable = obj.GetObservable(Avalonia.Controls.GridSplitter.ResizeBehaviorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.GridSplitter.ResizeBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.GridResizeBehavior>> ObserveBindingResizeBehavior(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.GridSplitter.ResizeBehaviorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.GridSplitter.ResizeBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingResizeBehavior<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<BindingValue<Avalonia.Controls.GridResizeBehavior>>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.GridSplitter.ResizeBehaviorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.GridSplitter.ResizeBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveResizeBehaviorChanged(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.ResizeBehaviorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.GridSplitter.ResizeBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnResizeBehaviorChanged<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.ResizeBehaviorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -384,6 +480,54 @@ public static partial class GridSplitterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.GridSplitter.ShowsPreviewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowsPreview(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.GridSplitter.ShowsPreviewProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.GridSplitter.ShowsPreviewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowsPreview<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.GridSplitter.ShowsPreviewProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.GridSplitter.ShowsPreviewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowsPreviewChanged(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.ShowsPreviewProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.GridSplitter.ShowsPreviewProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowsPreviewChanged<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.ShowsPreviewProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.GridSplitter.KeyboardIncrementProperty
 
     /// <summary>
@@ -478,6 +622,54 @@ public static partial class GridSplitterExtensions
     public static T OnKeyboardIncrement<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<System.Double>> handler) where T : Avalonia.Controls.GridSplitter
     {
         var observable = obj.GetObservable(Avalonia.Controls.GridSplitter.KeyboardIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.GridSplitter.KeyboardIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingKeyboardIncrement(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.GridSplitter.KeyboardIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.GridSplitter.KeyboardIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingKeyboardIncrement<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.GridSplitter.KeyboardIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.GridSplitter.KeyboardIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveKeyboardIncrementChanged(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.KeyboardIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.GridSplitter.KeyboardIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnKeyboardIncrementChanged<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.KeyboardIncrementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -580,6 +772,54 @@ public static partial class GridSplitterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.GridSplitter.DragIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingDragIncrement(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.GridSplitter.DragIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.GridSplitter.DragIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDragIncrement<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.GridSplitter.DragIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.GridSplitter.DragIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDragIncrementChanged(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.DragIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.GridSplitter.DragIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDragIncrementChanged<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.DragIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.GridSplitter.PreviewContentProperty
 
     /// <summary>
@@ -674,6 +914,54 @@ public static partial class GridSplitterExtensions
     public static T OnPreviewContent<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.GridSplitter
     {
         var observable = obj.GetObservable(Avalonia.Controls.GridSplitter.PreviewContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.GridSplitter.PreviewContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>> ObserveBindingPreviewContent(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.GridSplitter.PreviewContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.GridSplitter.PreviewContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPreviewContent<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Control>>>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.GridSplitter.PreviewContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.GridSplitter.PreviewContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePreviewContentChanged(this Avalonia.Controls.GridSplitter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.PreviewContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.GridSplitter.PreviewContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPreviewContentChanged<T>(this T obj, Action<Avalonia.Controls.GridSplitter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.GridSplitter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.GridSplitter.PreviewContentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/HeaderedContentControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/HeaderedContentControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class HeaderedContentControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingHeader(this Avalonia.Controls.Primitives.HeaderedContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeader<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedContentControl, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Primitives.HeaderedContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.Primitives.HeaderedContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.HeaderedContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class HeaderedContentControlExtensions
     public static T OnHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedContentControl, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.Primitives.HeaderedContentControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingHeaderTemplate(this Avalonia.Controls.Primitives.HeaderedContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedContentControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.Primitives.HeaderedContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderTemplateChanged(this Avalonia.Controls.Primitives.HeaderedContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderTemplateChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.HeaderedContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedContentControl.HeaderTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/HeaderedItemsControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/HeaderedItemsControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class HeaderedItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingHeader(this Avalonia.Controls.Primitives.HeaderedItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeader<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedItemsControl, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Primitives.HeaderedItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.Primitives.HeaderedItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.HeaderedItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class HeaderedItemsControlExtensions
     public static T OnHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedItemsControl, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.Primitives.HeaderedItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingHeaderTemplate(this Avalonia.Controls.Primitives.HeaderedItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedItemsControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.Primitives.HeaderedItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderTemplateChanged(this Avalonia.Controls.Primitives.HeaderedItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderTemplateChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.HeaderedItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedItemsControl.HeaderTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/HeaderedSelectingItemsControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/HeaderedSelectingItemsControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class HeaderedSelectingItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingHeader(this Avalonia.Controls.Primitives.HeaderedSelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeader<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedSelectingItemsControl, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Primitives.HeaderedSelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.Primitives.HeaderedSelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedSelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.HeaderedSelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class HeaderedSelectingItemsControlExtensions
     public static T OnHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedSelectingItemsControl, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.Primitives.HeaderedSelectingItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingHeaderTemplate(this Avalonia.Controls.Primitives.HeaderedSelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeaderTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedSelectingItemsControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.Primitives.HeaderedSelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderTemplateChanged(this Avalonia.Controls.Primitives.HeaderedSelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderTemplateChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.HeaderedSelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.HeaderedSelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.HeaderedSelectingItemsControl.HeaderTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/HyperlinkButton.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/HyperlinkButton.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class HyperlinkButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.HyperlinkButton.IsVisitedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsVisited(this Avalonia.Controls.HyperlinkButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.HyperlinkButton.IsVisitedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.HyperlinkButton.IsVisitedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsVisited<T>(this T obj, Action<Avalonia.Controls.HyperlinkButton, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.HyperlinkButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.HyperlinkButton.IsVisitedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.HyperlinkButton.IsVisitedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsVisitedChanged(this Avalonia.Controls.HyperlinkButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.HyperlinkButton.IsVisitedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.HyperlinkButton.IsVisitedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsVisitedChanged<T>(this T obj, Action<Avalonia.Controls.HyperlinkButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.HyperlinkButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.HyperlinkButton.IsVisitedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.HyperlinkButton.NavigateUriProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class HyperlinkButtonExtensions
     public static T OnNavigateUri<T>(this T obj, Action<Avalonia.Controls.HyperlinkButton, IObservable<System.Uri>> handler) where T : Avalonia.Controls.HyperlinkButton
     {
         var observable = obj.GetObservable(Avalonia.Controls.HyperlinkButton.NavigateUriProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.HyperlinkButton.NavigateUriProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Uri>> ObserveBindingNavigateUri(this Avalonia.Controls.HyperlinkButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.HyperlinkButton.NavigateUriProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.HyperlinkButton.NavigateUriProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingNavigateUri<T>(this T obj, Action<Avalonia.Controls.HyperlinkButton, IObservable<BindingValue<System.Uri>>> handler) where T : Avalonia.Controls.HyperlinkButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.HyperlinkButton.NavigateUriProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.HyperlinkButton.NavigateUriProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveNavigateUriChanged(this Avalonia.Controls.HyperlinkButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.HyperlinkButton.NavigateUriProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.HyperlinkButton.NavigateUriProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnNavigateUriChanged<T>(this T obj, Action<Avalonia.Controls.HyperlinkButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.HyperlinkButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.HyperlinkButton.NavigateUriProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Image.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Image.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ImageExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Image.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IImage>> ObserveBindingSource(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Image.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Image.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSource<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<BindingValue<Avalonia.Media.IImage>>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Image.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Image.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSourceChanged(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Image.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Image.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSourceChanged<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Image.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Image.BlendModeProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ImageExtensions
     public static T OnBlendMode<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<Avalonia.Media.Imaging.BitmapBlendingMode>> handler) where T : Avalonia.Controls.Image
     {
         var observable = obj.GetObservable(Avalonia.Controls.Image.BlendModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Image.BlendModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Imaging.BitmapBlendingMode>> ObserveBindingBlendMode(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Image.BlendModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Image.BlendModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBlendMode<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<BindingValue<Avalonia.Media.Imaging.BitmapBlendingMode>>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Image.BlendModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Image.BlendModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBlendModeChanged(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Image.BlendModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Image.BlendModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBlendModeChanged<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Image.BlendModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -637,6 +733,54 @@ public static partial class ImageExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Image.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Stretch>> ObserveBindingStretch(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Image.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Image.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStretch<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<BindingValue<Avalonia.Media.Stretch>>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Image.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Image.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStretchChanged(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Image.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Image.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStretchChanged<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Image.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Image.StretchProperty"/> property value to <see cref="Avalonia.Media.Stretch.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -778,6 +922,54 @@ public static partial class ImageExtensions
     public static T OnStretchDirection<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<Avalonia.Media.StretchDirection>> handler) where T : Avalonia.Controls.Image
     {
         var observable = obj.GetObservable(Avalonia.Controls.Image.StretchDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Image.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.StretchDirection>> ObserveBindingStretchDirection(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Image.StretchDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Image.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStretchDirection<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<BindingValue<Avalonia.Media.StretchDirection>>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Image.StretchDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Image.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStretchDirectionChanged(this Avalonia.Controls.Image obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Image.StretchDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Image.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStretchDirectionChanged<T>(this T obj, Action<Avalonia.Controls.Image, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Image
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Image.StretchDirectionProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ImageBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ImageBrush.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class ImageBrushExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ImageBrush.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IImageBrushSource>> ObserveBindingSource(this Avalonia.Media.ImageBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ImageBrush.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ImageBrush.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ImageBrush OnBindingSource(this Avalonia.Media.ImageBrush obj, Action<Avalonia.Media.ImageBrush, IObservable<BindingValue<Avalonia.Media.IImageBrushSource>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ImageBrush.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ImageBrush.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSourceChanged(this Avalonia.Media.ImageBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ImageBrush.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ImageBrush.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ImageBrush OnSourceChanged(this Avalonia.Media.ImageBrush obj, Action<Avalonia.Media.ImageBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ImageBrush.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/ImageDrawing.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ImageDrawing.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class ImageDrawingExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ImageDrawing.ImageSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IImage>> ObserveBindingImageSource(this Avalonia.Media.ImageDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ImageDrawing.ImageSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ImageDrawing.ImageSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ImageDrawing OnBindingImageSource(this Avalonia.Media.ImageDrawing obj, Action<Avalonia.Media.ImageDrawing, IObservable<BindingValue<Avalonia.Media.IImage>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ImageDrawing.ImageSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ImageDrawing.ImageSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveImageSourceChanged(this Avalonia.Media.ImageDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ImageDrawing.ImageSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ImageDrawing.ImageSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ImageDrawing OnImageSourceChanged(this Avalonia.Media.ImageDrawing obj, Action<Avalonia.Media.ImageDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ImageDrawing.ImageSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ImageDrawing.RectProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class ImageDrawingExtensions
     public static Avalonia.Media.ImageDrawing OnRect(this Avalonia.Media.ImageDrawing obj, Action<Avalonia.Media.ImageDrawing, IObservable<Avalonia.Rect>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.ImageDrawing.RectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ImageDrawing.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Rect>> ObserveBindingRect(this Avalonia.Media.ImageDrawing obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ImageDrawing.RectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ImageDrawing.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ImageDrawing OnBindingRect(this Avalonia.Media.ImageDrawing obj, Action<Avalonia.Media.ImageDrawing, IObservable<BindingValue<Avalonia.Rect>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ImageDrawing.RectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ImageDrawing.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRectChanged(this Avalonia.Media.ImageDrawing obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ImageDrawing.RectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ImageDrawing.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ImageDrawing OnRectChanged(this Avalonia.Media.ImageDrawing obj, Action<Avalonia.Media.ImageDrawing, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ImageDrawing.RectProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Inline.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Inline.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class InlineExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.Inline.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextDecorationCollection>> ObserveBindingTextDecorations(this Avalonia.Controls.Documents.Inline obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.Inline.TextDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.Inline.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextDecorations<T>(this T obj, Action<Avalonia.Controls.Documents.Inline, IObservable<BindingValue<Avalonia.Media.TextDecorationCollection>>> handler) where T : Avalonia.Controls.Documents.Inline
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.Inline.TextDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.Inline.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextDecorationsChanged(this Avalonia.Controls.Documents.Inline obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Inline.TextDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.Inline.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextDecorationsChanged<T>(this T obj, Action<Avalonia.Controls.Documents.Inline, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.Inline
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Inline.TextDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class InlineExtensions
     public static T OnBaselineAlignment<T>(this T obj, Action<Avalonia.Controls.Documents.Inline, IObservable<Avalonia.Media.BaselineAlignment>> handler) where T : Avalonia.Controls.Documents.Inline
     {
         var observable = obj.GetObservable(Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.BaselineAlignment>> ObserveBindingBaselineAlignment(this Avalonia.Controls.Documents.Inline obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBaselineAlignment<T>(this T obj, Action<Avalonia.Controls.Documents.Inline, IObservable<BindingValue<Avalonia.Media.BaselineAlignment>>> handler) where T : Avalonia.Controls.Documents.Inline
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBaselineAlignmentChanged(this Avalonia.Controls.Documents.Inline obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBaselineAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Documents.Inline, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.Inline
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Inline.BaselineAlignmentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/InlineUIContainer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/InlineUIContainer.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class InlineUIContainerExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.InlineUIContainer.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingChild(this Avalonia.Controls.Documents.InlineUIContainer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.InlineUIContainer.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.InlineUIContainer.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingChild<T>(this T obj, Action<Avalonia.Controls.Documents.InlineUIContainer, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.Documents.InlineUIContainer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.InlineUIContainer.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.InlineUIContainer.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildChanged(this Avalonia.Controls.Documents.InlineUIContainer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.InlineUIContainer.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.InlineUIContainer.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnChildChanged<T>(this T obj, Action<Avalonia.Controls.Documents.InlineUIContainer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.InlineUIContainer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.InlineUIContainer.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/InputElement.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/InputElement.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class InputElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.FocusableProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingFocusable(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.FocusableProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.FocusableProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFocusable<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.FocusableProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.FocusableProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFocusableChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.FocusableProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.FocusableProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFocusableChanged<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.FocusableProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.InputElement.IsEnabledProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class InputElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsEnabled(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.IsEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsEnabled<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.IsEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsEnabledChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsEnabledChanged<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.InputElement.IsEffectivelyEnabledProperty
 
     /// <summary>
@@ -242,6 +338,52 @@ public static partial class InputElementExtensions
     public static Avalonia.Input.InputElement OnIsEffectivelyEnabled(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Input.InputElement.IsEffectivelyEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.IsEffectivelyEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsEffectivelyEnabled(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.IsEffectivelyEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.IsEffectivelyEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnBindingIsEffectivelyEnabled(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.IsEffectivelyEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.IsEffectivelyEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsEffectivelyEnabledChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsEffectivelyEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.IsEffectivelyEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnIsEffectivelyEnabledChanged(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsEffectivelyEnabledProperty);
         handler(obj, observable);
         return obj;
     }
@@ -344,6 +486,54 @@ public static partial class InputElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.CursorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.Cursor>> ObserveBindingCursor(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.CursorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.CursorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCursor<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<Avalonia.Input.Cursor>>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.CursorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.CursorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCursorChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.CursorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.CursorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCursorChanged<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.CursorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty
 
     /// <summary>
@@ -388,6 +578,52 @@ public static partial class InputElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsKeyboardFocusWithin(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnBindingIsKeyboardFocusWithin(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsKeyboardFocusWithinChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnIsKeyboardFocusWithinChanged(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsKeyboardFocusWithinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.InputElement.IsFocusedProperty
 
     /// <summary>
@@ -428,6 +664,52 @@ public static partial class InputElementExtensions
     public static Avalonia.Input.InputElement OnIsFocused(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Input.InputElement.IsFocusedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.IsFocusedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsFocused(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.IsFocusedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.IsFocusedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnBindingIsFocused(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.IsFocusedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.IsFocusedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsFocusedChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsFocusedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.IsFocusedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnIsFocusedChanged(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsFocusedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -530,6 +812,54 @@ public static partial class InputElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.IsHitTestVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsHitTestVisible(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.IsHitTestVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.IsHitTestVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsHitTestVisible<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.IsHitTestVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.IsHitTestVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsHitTestVisibleChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsHitTestVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.IsHitTestVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsHitTestVisibleChanged<T>(this T obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.InputElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsHitTestVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.InputElement.IsPointerOverProperty
 
     /// <summary>
@@ -570,6 +900,52 @@ public static partial class InputElementExtensions
     public static Avalonia.Input.InputElement OnIsPointerOver(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Input.InputElement.IsPointerOverProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.InputElement.IsPointerOverProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsPointerOver(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.InputElement.IsPointerOverProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.InputElement.IsPointerOverProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnBindingIsPointerOver(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.InputElement.IsPointerOverProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.InputElement.IsPointerOverProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsPointerOverChanged(this Avalonia.Input.InputElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsPointerOverProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.InputElement.IsPointerOverProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Input.InputElement OnIsPointerOverChanged(this Avalonia.Input.InputElement obj, Action<Avalonia.Input.InputElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.InputElement.IsPointerOverProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ItemsControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ItemsControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingItemContainerTheme(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemContainerThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemContainerTheme<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemContainerThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemContainerThemeChanged(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemContainerThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemContainerThemeChanged<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemContainerThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ItemsControl.ItemCountProperty
 
     /// <summary>
@@ -144,6 +192,52 @@ public static partial class ItemsControlExtensions
     public static Avalonia.Controls.ItemsControl OnItemCount(this Avalonia.Controls.ItemsControl obj, Action<Avalonia.Controls.ItemsControl, IObservable<System.Int32>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ItemsControl.ItemCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingItemCount(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ItemsControl OnBindingItemCount(this Avalonia.Controls.ItemsControl obj, Action<Avalonia.Controls.ItemsControl, IObservable<BindingValue<System.Int32>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemCountProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemCountChanged(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemCountProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemCountProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ItemsControl OnItemCountChanged(this Avalonia.Controls.ItemsControl obj, Action<Avalonia.Controls.ItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemCountProperty);
         handler(obj, observable);
         return obj;
     }
@@ -246,6 +340,54 @@ public static partial class ItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Panel>>> ObserveBindingItemsPanel(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemsPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsPanel<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Panel>>>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemsPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsPanelChanged(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemsPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsPanelChanged<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemsPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ItemsControl.ItemsSourceProperty
 
     /// <summary>
@@ -340,6 +482,54 @@ public static partial class ItemsControlExtensions
     public static T OnItemsSource<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<System.Collections.IEnumerable>> handler) where T : Avalonia.Controls.ItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.ItemsControl.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.IEnumerable>> ObserveBindingItemsSource(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsSource<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<BindingValue<System.Collections.IEnumerable>>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsSourceChanged(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsSourceChanged<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemsSourceProperty);
         handler(obj, observable);
         return obj;
     }
@@ -442,6 +632,54 @@ public static partial class ItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingItemTemplate(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsControl.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemTemplate<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsControl.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemTemplateChanged(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsControl.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty
 
     /// <summary>
@@ -536,6 +774,54 @@ public static partial class ItemsControlExtensions
     public static T OnDisplayMemberBinding<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<Avalonia.Data.IBinding>> handler) where T : Avalonia.Controls.ItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Data.IBinding>> ObserveBindingDisplayMemberBinding(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayMemberBinding<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<BindingValue<Avalonia.Data.IBinding>>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayMemberBindingChanged(this Avalonia.Controls.ItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayMemberBindingChanged<T>(this T obj, Action<Avalonia.Controls.ItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsControl.DisplayMemberBindingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ItemsPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ItemsPresenter.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class ItemsPresenterExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Panel>>> ObserveBindingItemsPanel(this Avalonia.Controls.Presenters.ItemsPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsPanel<T>(this T obj, Action<Avalonia.Controls.Presenters.ItemsPresenter, IObservable<BindingValue<Avalonia.Controls.ITemplate<Avalonia.Controls.Panel>>>> handler) where T : Avalonia.Controls.Presenters.ItemsPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsPanelChanged(this Avalonia.Controls.Presenters.ItemsPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsPanelChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ItemsPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ItemsPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ItemsPresenter.ItemsPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/ItemsRepeater.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ItemsRepeater.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ItemsRepeaterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalCacheLength(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalCacheLength<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalCacheLengthChanged(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalCacheLengthChanged<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.HorizontalCacheLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ItemsRepeater.ItemTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ItemsRepeaterExtensions
     public static T OnItemTemplate<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.ItemsRepeater
     {
         var observable = obj.GetObservable(Avalonia.Controls.ItemsRepeater.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingItemTemplate(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemTemplate<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemTemplateChanged(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.ItemTemplateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class ItemsRepeaterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.IEnumerable>> ObserveBindingItemsSource(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsSource<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<BindingValue<System.Collections.IEnumerable>>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsSourceChanged(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsRepeater.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsSourceChanged<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ItemsRepeater.LayoutProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class ItemsRepeaterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.LayoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.AttachedLayout>> ObserveBindingLayout(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.LayoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.LayoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLayout<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<BindingValue<Avalonia.Layout.AttachedLayout>>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.LayoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsRepeater.LayoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLayoutChanged(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.LayoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsRepeater.LayoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLayoutChanged<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.LayoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class ItemsRepeaterExtensions
     public static T OnVerticalCacheLength<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<System.Double>> handler) where T : Avalonia.Controls.ItemsRepeater
     {
         var observable = obj.GetObservable(Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalCacheLength(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalCacheLength<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalCacheLengthChanged(this Avalonia.Controls.ItemsRepeater obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalCacheLengthChanged<T>(this T obj, Action<Avalonia.Controls.ItemsRepeater, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ItemsRepeater
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ItemsRepeater.VerticalCacheLengthProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/KeyBinding.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/KeyBinding.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class KeyBindingExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.KeyBinding.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Windows.Input.ICommand>> ObserveBindingCommand(this Avalonia.Input.KeyBinding obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.KeyBinding.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.KeyBinding.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommand<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<BindingValue<System.Windows.Input.ICommand>>> handler) where T : Avalonia.Input.KeyBinding
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.KeyBinding.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.KeyBinding.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandChanged(this Avalonia.Input.KeyBinding obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.KeyBinding.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.KeyBinding.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandChanged<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.KeyBinding
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.KeyBinding.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.KeyBinding.CommandParameterProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class KeyBindingExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.KeyBinding.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingCommandParameter(this Avalonia.Input.KeyBinding obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.KeyBinding.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.KeyBinding.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommandParameter<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Input.KeyBinding
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.KeyBinding.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.KeyBinding.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandParameterChanged(this Avalonia.Input.KeyBinding obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.KeyBinding.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.KeyBinding.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandParameterChanged<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.KeyBinding
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.KeyBinding.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.KeyBinding.GestureProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class KeyBindingExtensions
     public static T OnGesture<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<Avalonia.Input.KeyGesture>> handler) where T : Avalonia.Input.KeyBinding
     {
         var observable = obj.GetObservable(Avalonia.Input.KeyBinding.GestureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.KeyBinding.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.KeyGesture>> ObserveBindingGesture(this Avalonia.Input.KeyBinding obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.KeyBinding.GestureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.KeyBinding.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGesture<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<BindingValue<Avalonia.Input.KeyGesture>>> handler) where T : Avalonia.Input.KeyBinding
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.KeyBinding.GestureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.KeyBinding.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGestureChanged(this Avalonia.Input.KeyBinding obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.KeyBinding.GestureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.KeyBinding.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGestureChanged<T>(this T obj, Action<Avalonia.Input.KeyBinding, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.KeyBinding
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.KeyBinding.GestureProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Label.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Label.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class LabelExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Label.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.IInputElement>> ObserveBindingTarget(this Avalonia.Controls.Label obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Label.TargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Label.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTarget<T>(this T obj, Action<Avalonia.Controls.Label, IObservable<BindingValue<Avalonia.Input.IInputElement>>> handler) where T : Avalonia.Controls.Label
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Label.TargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Label.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTargetChanged(this Avalonia.Controls.Label obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Label.TargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Label.TargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTargetChanged<T>(this T obj, Action<Avalonia.Controls.Label, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Label
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Label.TargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/LayoutTransformControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/LayoutTransformControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class LayoutTransformControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.ITransform>> ObserveBindingLayoutTransform(this Avalonia.Controls.LayoutTransformControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLayoutTransform<T>(this T obj, Action<Avalonia.Controls.LayoutTransformControl, IObservable<BindingValue<Avalonia.Media.ITransform>>> handler) where T : Avalonia.Controls.LayoutTransformControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLayoutTransformChanged(this Avalonia.Controls.LayoutTransformControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLayoutTransformChanged<T>(this T obj, Action<Avalonia.Controls.LayoutTransformControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.LayoutTransformControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.LayoutTransformControl.LayoutTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class LayoutTransformControlExtensions
     public static T OnUseRenderTransform<T>(this T obj, Action<Avalonia.Controls.LayoutTransformControl, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.LayoutTransformControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseRenderTransform(this Avalonia.Controls.LayoutTransformControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseRenderTransform<T>(this T obj, Action<Avalonia.Controls.LayoutTransformControl, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.LayoutTransformControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseRenderTransformChanged(this Avalonia.Controls.LayoutTransformControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseRenderTransformChanged<T>(this T obj, Action<Avalonia.Controls.LayoutTransformControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.LayoutTransformControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.LayoutTransformControl.UseRenderTransformProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Layoutable.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Layoutable.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class LayoutableExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.DesiredSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingDesiredSize(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.DesiredSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.DesiredSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Layout.Layoutable OnBindingDesiredSize(this Avalonia.Layout.Layoutable obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.DesiredSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.DesiredSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDesiredSizeChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.DesiredSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.DesiredSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Layout.Layoutable OnDesiredSizeChanged(this Avalonia.Layout.Layoutable obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.DesiredSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.Layoutable.WidthProperty
 
     /// <summary>
@@ -144,6 +190,54 @@ public static partial class LayoutableExtensions
     public static T OnWidth<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Double>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Layout.Layoutable.WidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingWidth(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.WidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWidth<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.WidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWidthChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.WidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.WidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWidthChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.WidthProperty);
         handler(obj, observable);
         return obj;
     }
@@ -246,6 +340,54 @@ public static partial class LayoutableExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHeight(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.HeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeight<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.HeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeightChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.HeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeightChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.HeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.Layoutable.MinWidthProperty
 
     /// <summary>
@@ -340,6 +482,54 @@ public static partial class LayoutableExtensions
     public static T OnMinWidth<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Double>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Layout.Layoutable.MinWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinWidth(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.MinWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinWidth<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.MinWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinWidthChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MinWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.MinWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinWidthChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MinWidthProperty);
         handler(obj, observable);
         return obj;
     }
@@ -442,6 +632,54 @@ public static partial class LayoutableExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxWidth(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.MaxWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxWidth<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.MaxWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxWidthChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MaxWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.MaxWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxWidthChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MaxWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.Layoutable.MinHeightProperty
 
     /// <summary>
@@ -536,6 +774,54 @@ public static partial class LayoutableExtensions
     public static T OnMinHeight<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Double>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Layout.Layoutable.MinHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinHeight(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.MinHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinHeight<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.MinHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinHeightChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MinHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinHeightChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MinHeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -638,6 +924,54 @@ public static partial class LayoutableExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxHeight(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.MaxHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxHeight<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.MaxHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxHeightChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MaxHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxHeightChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MaxHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.Layoutable.MarginProperty
 
     /// <summary>
@@ -736,6 +1070,54 @@ public static partial class LayoutableExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.MarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingMargin(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.MarginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.MarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMargin<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.MarginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.MarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMarginChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MarginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.MarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMarginChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.MarginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.Layoutable.HorizontalAlignmentProperty
 
     /// <summary>
@@ -830,6 +1212,54 @@ public static partial class LayoutableExtensions
     public static T OnHorizontalAlignment<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Layout.Layoutable.HorizontalAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.HorizontalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalAlignment(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.HorizontalAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.HorizontalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalAlignment<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.HorizontalAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.HorizontalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalAlignmentChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.HorizontalAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.HorizontalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalAlignmentChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.HorizontalAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -981,6 +1411,54 @@ public static partial class LayoutableExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.VerticalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalAlignment(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.VerticalAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.VerticalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalAlignment<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.VerticalAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.VerticalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalAlignmentChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.VerticalAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.VerticalAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalAlignmentChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.VerticalAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Layout.Layoutable.VerticalAlignmentProperty"/> property value to <see cref="Avalonia.Layout.VerticalAlignment.Stretch"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1122,6 +1600,54 @@ public static partial class LayoutableExtensions
     public static T OnUseLayoutRounding<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Boolean>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Layout.Layoutable.UseLayoutRoundingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.Layoutable.UseLayoutRoundingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseLayoutRounding(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.Layoutable.UseLayoutRoundingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.Layoutable.UseLayoutRoundingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseLayoutRounding<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.Layoutable.UseLayoutRoundingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.Layoutable.UseLayoutRoundingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseLayoutRoundingChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.UseLayoutRoundingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.Layoutable.UseLayoutRoundingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseLayoutRoundingChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.Layoutable.UseLayoutRoundingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Line.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Line.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class LineExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Line.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingStartPoint(this Avalonia.Controls.Shapes.Line obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Line.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Line.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStartPoint<T>(this T obj, Action<Avalonia.Controls.Shapes.Line, IObservable<BindingValue<Avalonia.Point>>> handler) where T : Avalonia.Controls.Shapes.Line
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Line.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Line.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStartPointChanged(this Avalonia.Controls.Shapes.Line obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Line.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Line.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStartPointChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Line, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Line
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Line.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Line.EndPointProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class LineExtensions
     public static T OnEndPoint<T>(this T obj, Action<Avalonia.Controls.Shapes.Line, IObservable<Avalonia.Point>> handler) where T : Avalonia.Controls.Shapes.Line
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Line.EndPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Line.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingEndPoint(this Avalonia.Controls.Shapes.Line obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Line.EndPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Line.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingEndPoint<T>(this T obj, Action<Avalonia.Controls.Shapes.Line, IObservable<BindingValue<Avalonia.Point>>> handler) where T : Avalonia.Controls.Shapes.Line
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Line.EndPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Line.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEndPointChanged(this Avalonia.Controls.Shapes.Line obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Line.EndPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Line.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnEndPointChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Line, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Line
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Line.EndPointProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/LineGeometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/LineGeometry.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class LineGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.LineGeometry.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingStartPoint(this Avalonia.Media.LineGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.LineGeometry.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.LineGeometry.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStartPoint<T>(this T obj, Action<Avalonia.Media.LineGeometry, IObservable<BindingValue<Avalonia.Point>>> handler) where T : Avalonia.Media.LineGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.LineGeometry.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.LineGeometry.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStartPointChanged(this Avalonia.Media.LineGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.LineGeometry.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.LineGeometry.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStartPointChanged<T>(this T obj, Action<Avalonia.Media.LineGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.LineGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.LineGeometry.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.LineGeometry.EndPointProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class LineGeometryExtensions
     public static T OnEndPoint<T>(this T obj, Action<Avalonia.Media.LineGeometry, IObservable<Avalonia.Point>> handler) where T : Avalonia.Media.LineGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.LineGeometry.EndPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.LineGeometry.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingEndPoint(this Avalonia.Media.LineGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.LineGeometry.EndPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.LineGeometry.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingEndPoint<T>(this T obj, Action<Avalonia.Media.LineGeometry, IObservable<BindingValue<Avalonia.Point>>> handler) where T : Avalonia.Media.LineGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.LineGeometry.EndPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.LineGeometry.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEndPointChanged(this Avalonia.Media.LineGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.LineGeometry.EndPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.LineGeometry.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnEndPointChanged<T>(this T obj, Action<Avalonia.Media.LineGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.LineGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.LineGeometry.EndPointProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/LineSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/LineSegment.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class LineSegmentExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.LineSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint(this Avalonia.Media.LineSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.LineSegment.PointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.LineSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.LineSegment OnBindingPoint(this Avalonia.Media.LineSegment obj, Action<Avalonia.Media.LineSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.LineSegment.PointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.LineSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointChanged(this Avalonia.Media.LineSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.LineSegment.PointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.LineSegment.PointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.LineSegment OnPointChanged(this Avalonia.Media.LineSegment obj, Action<Avalonia.Media.LineSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.LineSegment.PointProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/LinearGradientBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/LinearGradientBrush.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class LinearGradientBrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.LinearGradientBrush.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingStartPoint(this Avalonia.Media.LinearGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.LinearGradientBrush.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.LinearGradientBrush.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.LinearGradientBrush OnBindingStartPoint(this Avalonia.Media.LinearGradientBrush obj, Action<Avalonia.Media.LinearGradientBrush, IObservable<BindingValue<Avalonia.RelativePoint>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.LinearGradientBrush.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.LinearGradientBrush.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStartPointChanged(this Avalonia.Media.LinearGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.LinearGradientBrush.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.LinearGradientBrush.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.LinearGradientBrush OnStartPointChanged(this Avalonia.Media.LinearGradientBrush obj, Action<Avalonia.Media.LinearGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.LinearGradientBrush.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.LinearGradientBrush.EndPointProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class LinearGradientBrushExtensions
     public static Avalonia.Media.LinearGradientBrush OnEndPoint(this Avalonia.Media.LinearGradientBrush obj, Action<Avalonia.Media.LinearGradientBrush, IObservable<Avalonia.RelativePoint>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.LinearGradientBrush.EndPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.LinearGradientBrush.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingEndPoint(this Avalonia.Media.LinearGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.LinearGradientBrush.EndPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.LinearGradientBrush.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.LinearGradientBrush OnBindingEndPoint(this Avalonia.Media.LinearGradientBrush obj, Action<Avalonia.Media.LinearGradientBrush, IObservable<BindingValue<Avalonia.RelativePoint>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.LinearGradientBrush.EndPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.LinearGradientBrush.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEndPointChanged(this Avalonia.Media.LinearGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.LinearGradientBrush.EndPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.LinearGradientBrush.EndPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.LinearGradientBrush OnEndPointChanged(this Avalonia.Media.LinearGradientBrush obj, Action<Avalonia.Media.LinearGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.LinearGradientBrush.EndPointProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ListBox.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ListBox.Extensions.g.cs
@@ -49,4 +49,50 @@ public static partial class ListBoxExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ListBox.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.IScrollable>> ObserveBindingScroll(this Avalonia.Controls.ListBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ListBox.ScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ListBox.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ListBox OnBindingScroll(this Avalonia.Controls.ListBox obj, Action<Avalonia.Controls.ListBox, IObservable<BindingValue<Avalonia.Controls.Primitives.IScrollable>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ListBox.ScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ListBox.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveScrollChanged(this Avalonia.Controls.ListBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ListBox.ScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ListBox.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ListBox OnScrollChanged(this Avalonia.Controls.ListBox obj, Action<Avalonia.Controls.ListBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ListBox.ScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/MaskedTextBox.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/MaskedTextBox.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class MaskedTextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAsciiOnly(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAsciiOnly<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAsciiOnlyChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAsciiOnlyChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.AsciiOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MaskedTextBox.CultureProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class MaskedTextBoxExtensions
     public static T OnCulture<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<System.Globalization.CultureInfo>> handler) where T : Avalonia.Controls.MaskedTextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.MaskedTextBox.CultureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.CultureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Globalization.CultureInfo>> ObserveBindingCulture(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.CultureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.CultureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCulture<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Globalization.CultureInfo>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.CultureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.CultureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCultureChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.CultureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.CultureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCultureChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.CultureProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class MaskedTextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingHidePromptOnLeave(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHidePromptOnLeave<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHidePromptOnLeaveChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHidePromptOnLeaveChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.HidePromptOnLeaveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MaskedTextBox.MaskCompletedProperty
 
     /// <summary>
@@ -344,6 +488,52 @@ public static partial class MaskedTextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskCompletedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.Boolean>>> ObserveBindingMaskCompleted(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.MaskCompletedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskCompletedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.MaskedTextBox OnBindingMaskCompleted(this Avalonia.Controls.MaskedTextBox obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Nullable<System.Boolean>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.MaskCompletedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskCompletedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaskCompletedChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.MaskCompletedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskCompletedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.MaskedTextBox OnMaskCompletedChanged(this Avalonia.Controls.MaskedTextBox obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.MaskCompletedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MaskedTextBox.MaskFullProperty
 
     /// <summary>
@@ -384,6 +574,52 @@ public static partial class MaskedTextBoxExtensions
     public static Avalonia.Controls.MaskedTextBox OnMaskFull(this Avalonia.Controls.MaskedTextBox obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<System.Nullable<System.Boolean>>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.MaskedTextBox.MaskFullProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskFullProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.Boolean>>> ObserveBindingMaskFull(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.MaskFullProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskFullProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.MaskedTextBox OnBindingMaskFull(this Avalonia.Controls.MaskedTextBox obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Nullable<System.Boolean>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.MaskFullProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskFullProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaskFullChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.MaskFullProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskFullProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.MaskedTextBox OnMaskFullChanged(this Avalonia.Controls.MaskedTextBox obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.MaskFullProperty);
         handler(obj, observable);
         return obj;
     }
@@ -486,6 +722,54 @@ public static partial class MaskedTextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingMask(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.MaskProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMask<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.MaskProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaskChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.MaskProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.MaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaskChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.MaskProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MaskedTextBox.PromptCharProperty
 
     /// <summary>
@@ -580,6 +864,54 @@ public static partial class MaskedTextBoxExtensions
     public static T OnPromptChar<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<System.Char>> handler) where T : Avalonia.Controls.MaskedTextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.MaskedTextBox.PromptCharProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.PromptCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Char>> ObserveBindingPromptChar(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.PromptCharProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.PromptCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPromptChar<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Char>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.PromptCharProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.PromptCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePromptCharChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.PromptCharProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.PromptCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPromptCharChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.PromptCharProperty);
         handler(obj, observable);
         return obj;
     }
@@ -682,6 +1014,54 @@ public static partial class MaskedTextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingResetOnPrompt(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingResetOnPrompt<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveResetOnPromptChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnResetOnPromptChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.ResetOnPromptProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty
 
     /// <summary>
@@ -776,6 +1156,54 @@ public static partial class MaskedTextBoxExtensions
     public static T OnResetOnSpace<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.MaskedTextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingResetOnSpace(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingResetOnSpace<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveResetOnSpaceChanged(this Avalonia.Controls.MaskedTextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnResetOnSpaceChanged<T>(this T obj, Action<Avalonia.Controls.MaskedTextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MaskedTextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MaskedTextBox.ResetOnSpaceProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/MatrixTransform.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/MatrixTransform.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class MatrixTransformExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.MatrixTransform.MatrixProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Matrix>> ObserveBindingMatrix(this Avalonia.Media.MatrixTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.MatrixTransform.MatrixProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.MatrixTransform.MatrixProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.MatrixTransform OnBindingMatrix(this Avalonia.Media.MatrixTransform obj, Action<Avalonia.Media.MatrixTransform, IObservable<BindingValue<Avalonia.Matrix>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.MatrixTransform.MatrixProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.MatrixTransform.MatrixProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMatrixChanged(this Avalonia.Media.MatrixTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.MatrixTransform.MatrixProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.MatrixTransform.MatrixProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.MatrixTransform OnMatrixChanged(this Avalonia.Media.MatrixTransform obj, Action<Avalonia.Media.MatrixTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.MatrixTransform.MatrixProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/MenuBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/MenuBase.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class MenuBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsOpen(this Avalonia.Controls.MenuBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuBase.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.MenuBase OnBindingIsOpen(this Avalonia.Controls.MenuBase obj, Action<Avalonia.Controls.MenuBase, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuBase.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsOpenChanged(this Avalonia.Controls.MenuBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuBase.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuBase.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.MenuBase OnIsOpenChanged(this Avalonia.Controls.MenuBase obj, Action<Avalonia.Controls.MenuBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuBase.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuBase.OpenedEvent
 
     /// <summary>

--- a/src/NXUI/Generated/Extensions/MenuFlyout.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/MenuFlyout.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class MenuFlyoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuFlyout.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.IEnumerable>> ObserveBindingItemsSource(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuFlyout.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsSource<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<BindingValue<System.Collections.IEnumerable>>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuFlyout.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsSourceChanged(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.ItemsSourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuFlyout.ItemsSourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsSourceChanged<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.ItemsSourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuFlyout.ItemTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class MenuFlyoutExtensions
     public static T OnItemTemplate<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.MenuFlyout
     {
         var observable = obj.GetObservable(Avalonia.Controls.MenuFlyout.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuFlyout.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingItemTemplate(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuFlyout.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemTemplate<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.ItemTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuFlyout.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemTemplateChanged(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.ItemTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuFlyout.ItemTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemTemplateChanged<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.ItemTemplateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class MenuFlyoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingItemContainerTheme(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemContainerTheme<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemContainerThemeChanged(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemContainerThemeChanged<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.ItemContainerThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class MenuFlyoutExtensions
     public static T OnFlyoutPresenterTheme<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<Avalonia.Styling.ControlTheme>> handler) where T : Avalonia.Controls.MenuFlyout
     {
         var observable = obj.GetObservable(Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingFlyoutPresenterTheme(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFlyoutPresenterTheme<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFlyoutPresenterThemeChanged(this Avalonia.Controls.MenuFlyout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFlyoutPresenterThemeChanged<T>(this T obj, Action<Avalonia.Controls.MenuFlyout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuFlyout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuFlyout.FlyoutPresenterThemeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/MenuItem.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/MenuItem.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class MenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Windows.Input.ICommand>> ObserveBindingCommand(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommand<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Windows.Input.ICommand>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuItem.CommandParameterProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class MenuItemExtensions
     public static T OnCommandParameter<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<System.Object>> handler) where T : Avalonia.Controls.MenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.MenuItem.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingCommandParameter(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommandParameter<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandParameterChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandParameterChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.CommandParameterProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class MenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingIcon(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIcon<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIconChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIconChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuItem.InputGestureProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class MenuItemExtensions
     public static T OnInputGesture<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<Avalonia.Input.KeyGesture>> handler) where T : Avalonia.Controls.MenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.MenuItem.InputGestureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.InputGestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.KeyGesture>> ObserveBindingInputGesture(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.InputGestureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.InputGestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInputGesture<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<Avalonia.Input.KeyGesture>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.InputGestureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.InputGestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInputGestureChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.InputGestureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.InputGestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInputGestureChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.InputGestureProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class MenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.IsSubMenuOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSubMenuOpen(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.IsSubMenuOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.IsSubMenuOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsSubMenuOpen<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.IsSubMenuOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.IsSubMenuOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSubMenuOpenChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.IsSubMenuOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.IsSubMenuOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsSubMenuOpenChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.IsSubMenuOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuItem.StaysOpenOnClickProperty
 
     /// <summary>
@@ -594,6 +834,54 @@ public static partial class MenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.StaysOpenOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingStaysOpenOnClick(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.StaysOpenOnClickProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.StaysOpenOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStaysOpenOnClick<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.StaysOpenOnClickProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.StaysOpenOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStaysOpenOnClickChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.StaysOpenOnClickProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.StaysOpenOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStaysOpenOnClickChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.StaysOpenOnClickProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuItem.ToggleTypeProperty
 
     /// <summary>
@@ -688,6 +976,54 @@ public static partial class MenuItemExtensions
     public static T OnToggleType<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<Avalonia.Controls.MenuItemToggleType>> handler) where T : Avalonia.Controls.MenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.MenuItem.ToggleTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.MenuItemToggleType>> ObserveBindingToggleType(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.ToggleTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingToggleType<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<Avalonia.Controls.MenuItemToggleType>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.ToggleTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveToggleTypeChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.ToggleTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnToggleTypeChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.ToggleTypeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -826,6 +1162,54 @@ public static partial class MenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsChecked(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsChecked<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsCheckedChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsCheckedChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.MenuItem.GroupNameProperty
 
     /// <summary>
@@ -920,6 +1304,54 @@ public static partial class MenuItemExtensions
     public static T OnGroupName<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<System.String>> handler) where T : Avalonia.Controls.MenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.MenuItem.GroupNameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.MenuItem.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingGroupName(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.MenuItem.GroupNameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.MenuItem.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGroupName<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.MenuItem.GroupNameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.MenuItem.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGroupNameChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.GroupNameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.MenuItem.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGroupNameChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.MenuItem.GroupNameProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/NativeMenu.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NativeMenu.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class NativeMenuExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenu.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.NativeMenuItem>> ObserveBindingParent(this Avalonia.Controls.NativeMenu obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenu.ParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenu.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.NativeMenu OnBindingParent(this Avalonia.Controls.NativeMenu obj, Action<Avalonia.Controls.NativeMenu, IObservable<BindingValue<Avalonia.Controls.NativeMenuItem>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenu.ParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenu.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveParentChanged(this Avalonia.Controls.NativeMenu obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenu.ParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenu.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.NativeMenu OnParentChanged(this Avalonia.Controls.NativeMenu obj, Action<Avalonia.Controls.NativeMenu, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenu.ParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty
 
     /// <summary>
@@ -148,6 +194,54 @@ public static partial class NativeMenuExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsNativeMenuExported(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsNativeMenuExported<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsNativeMenuExportedChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsNativeMenuExportedChanged<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenu.IsNativeMenuExportedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenu.MenuProperty
 
     /// <summary>
@@ -242,6 +336,54 @@ public static partial class NativeMenuExtensions
     public static T OnMenu<T>(this T obj, Action<Avalonia.AvaloniaObject, IObservable<Avalonia.Controls.NativeMenu>> handler) where T : Avalonia.AvaloniaObject
     {
         var observable = obj.GetObservable(Avalonia.Controls.NativeMenu.MenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenu.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.NativeMenu>> ObserveBindingMenu(this Avalonia.AvaloniaObject obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenu.MenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenu.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMenu<T>(this T obj, Action<Avalonia.AvaloniaObject, IObservable<BindingValue<Avalonia.Controls.NativeMenu>>> handler) where T : Avalonia.AvaloniaObject
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenu.MenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenu.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMenuChanged(this Avalonia.AvaloniaObject obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenu.MenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenu.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMenuChanged<T>(this T obj, Action<Avalonia.AvaloniaObject, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.AvaloniaObject
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenu.MenuProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/NativeMenuBar.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NativeMenuBar.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class NativeMenuBarExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingEnableMenuItemClickForwarding(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingEnableMenuItemClickForwarding<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEnableMenuItemClickForwardingChanged(this Avalonia.Controls.MenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnEnableMenuItemClickForwardingChanged<T>(this T obj, Action<Avalonia.Controls.MenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.MenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuBar.EnableMenuItemClickForwardingProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/NativeMenuItem.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NativeMenuItem.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class NativeMenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.NativeMenu>> ObserveBindingMenu(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.MenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMenu<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<Avalonia.Controls.NativeMenu>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.MenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMenuChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.MenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMenuChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.MenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenuItem.IconProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class NativeMenuItemExtensions
     public static T OnIcon<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<Avalonia.Media.Imaging.Bitmap>> handler) where T : Avalonia.Controls.NativeMenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.NativeMenuItem.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Imaging.Bitmap>> ObserveBindingIcon(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIcon<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<Avalonia.Media.Imaging.Bitmap>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIconChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIconChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IconProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class NativeMenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingHeader(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeader<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeaderChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenuItem.ToolTipProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class NativeMenuItemExtensions
     public static T OnToolTip<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<System.String>> handler) where T : Avalonia.Controls.NativeMenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.NativeMenuItem.ToolTipProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.ToolTipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingToolTip(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.ToolTipProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.ToolTipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingToolTip<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.ToolTipProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.ToolTipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveToolTipChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.ToolTipProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.ToolTipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnToolTipChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.ToolTipProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class NativeMenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.KeyGesture>> ObserveBindingGesture(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.GestureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGesture<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<Avalonia.Input.KeyGesture>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.GestureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGestureChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.GestureProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.GestureProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGestureChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.GestureProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenuItem.IsCheckedProperty
 
     /// <summary>
@@ -594,6 +834,54 @@ public static partial class NativeMenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsChecked(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsChecked<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsCheckedChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsCheckedChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenuItem.ToggleTypeProperty
 
     /// <summary>
@@ -688,6 +976,54 @@ public static partial class NativeMenuItemExtensions
     public static T OnToggleType<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<Avalonia.Controls.NativeMenuItemToggleType>> handler) where T : Avalonia.Controls.NativeMenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.NativeMenuItem.ToggleTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.NativeMenuItemToggleType>> ObserveBindingToggleType(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.ToggleTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingToggleType<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<Avalonia.Controls.NativeMenuItemToggleType>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.ToggleTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveToggleTypeChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.ToggleTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.ToggleTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnToggleTypeChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.ToggleTypeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -826,6 +1162,54 @@ public static partial class NativeMenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Windows.Input.ICommand>> ObserveBindingCommand(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommand<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.Windows.Input.ICommand>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenuItem.CommandParameterProperty
 
     /// <summary>
@@ -920,6 +1304,54 @@ public static partial class NativeMenuItemExtensions
     public static T OnCommandParameter<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<System.Object>> handler) where T : Avalonia.Controls.NativeMenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.NativeMenuItem.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingCommandParameter(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommandParameter<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandParameterChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandParameterChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.CommandParameterProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1022,6 +1454,54 @@ public static partial class NativeMenuItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsEnabled(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IsEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsEnabled<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IsEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsEnabledChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IsEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IsEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsEnabledChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IsEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NativeMenuItem.IsVisibleProperty
 
     /// <summary>
@@ -1116,6 +1596,54 @@ public static partial class NativeMenuItemExtensions
     public static T OnIsVisible<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.NativeMenuItem
     {
         var observable = obj.GetObservable(Avalonia.Controls.NativeMenuItem.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsVisible(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItem.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsVisible<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItem.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsVisibleChanged(this Avalonia.Controls.NativeMenuItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItem.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.NativeMenuItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NativeMenuItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItem.IsVisibleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/NativeMenuItemBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NativeMenuItemBase.Extensions.g.cs
@@ -49,4 +49,50 @@ public static partial class NativeMenuItemBaseExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NativeMenuItemBase.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.NativeMenu>> ObserveBindingParent(this Avalonia.Controls.NativeMenuItemBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NativeMenuItemBase.ParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NativeMenuItemBase.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.NativeMenuItemBase OnBindingParent(this Avalonia.Controls.NativeMenuItemBase obj, Action<Avalonia.Controls.NativeMenuItemBase, IObservable<BindingValue<Avalonia.Controls.NativeMenu>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NativeMenuItemBase.ParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NativeMenuItemBase.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveParentChanged(this Avalonia.Controls.NativeMenuItemBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItemBase.ParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NativeMenuItemBase.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.NativeMenuItemBase OnParentChanged(this Avalonia.Controls.NativeMenuItemBase obj, Action<Avalonia.Controls.NativeMenuItemBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NativeMenuItemBase.ParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/NonVirtualizingStackLayout.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NonVirtualizingStackLayout.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class NonVirtualizingStackLayoutExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Layout.NonVirtualizingStackLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Layout.NonVirtualizingStackLayout, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Layout.NonVirtualizingStackLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Layout.NonVirtualizingStackLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Layout.NonVirtualizingStackLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.NonVirtualizingStackLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Layout.NonVirtualizingStackLayout.OrientationProperty"/> property value to <see cref="Avalonia.Layout.Orientation.Horizontal"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -222,6 +270,54 @@ public static partial class NonVirtualizingStackLayoutExtensions
     public static T OnSpacing<T>(this T obj, Action<Avalonia.Layout.NonVirtualizingStackLayout, IObservable<System.Double>> handler) where T : Avalonia.Layout.NonVirtualizingStackLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSpacing(this Avalonia.Layout.NonVirtualizingStackLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSpacing<T>(this T obj, Action<Avalonia.Layout.NonVirtualizingStackLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.NonVirtualizingStackLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSpacingChanged(this Avalonia.Layout.NonVirtualizingStackLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSpacingChanged<T>(this T obj, Action<Avalonia.Layout.NonVirtualizingStackLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.NonVirtualizingStackLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.NonVirtualizingStackLayout.SpacingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/NotificationCard.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NotificationCard.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class NotificationCardExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsClosing(this Avalonia.Controls.Notifications.NotificationCard obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Notifications.NotificationCard OnBindingIsClosing(this Avalonia.Controls.Notifications.NotificationCard obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsClosingChanged(this Avalonia.Controls.Notifications.NotificationCard obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Notifications.NotificationCard OnIsClosingChanged(this Avalonia.Controls.Notifications.NotificationCard obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty
 
     /// <summary>
@@ -148,6 +194,54 @@ public static partial class NotificationCardExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsClosed(this Avalonia.Controls.Notifications.NotificationCard obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsClosed<T>(this T obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Notifications.NotificationCard
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsClosedChanged(this Avalonia.Controls.Notifications.NotificationCard obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsClosedChanged<T>(this T obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Notifications.NotificationCard
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.IsClosedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty
 
     /// <summary>
@@ -242,6 +336,54 @@ public static partial class NotificationCardExtensions
     public static T OnNotificationType<T>(this T obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<Avalonia.Controls.Notifications.NotificationType>> handler) where T : Avalonia.Controls.Notifications.NotificationCard
     {
         var observable = obj.GetObservable(Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Notifications.NotificationType>> ObserveBindingNotificationType(this Avalonia.Controls.Notifications.NotificationCard obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingNotificationType<T>(this T obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<BindingValue<Avalonia.Controls.Notifications.NotificationType>>> handler) where T : Avalonia.Controls.Notifications.NotificationCard
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveNotificationTypeChanged(this Avalonia.Controls.Notifications.NotificationCard obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnNotificationTypeChanged<T>(this T obj, Action<Avalonia.Controls.Notifications.NotificationCard, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Notifications.NotificationCard
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.NotificationTypeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -388,6 +530,54 @@ public static partial class NotificationCardExtensions
     public static T OnCloseOnClick<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Button
     {
         var observable = obj.GetObservable(Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCloseOnClick(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCloseOnClick<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCloseOnClickChanged(this Avalonia.Controls.Button obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCloseOnClickChanged<T>(this T obj, Action<Avalonia.Controls.Button, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Button
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.NotificationCard.CloseOnClickProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/NumericUpDown.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/NumericUpDown.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAllowSpin(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.AllowSpinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAllowSpin<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.AllowSpinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAllowSpinChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.AllowSpinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.AllowSpinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAllowSpinChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.AllowSpinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class NumericUpDownExtensions
     public static T OnButtonSpinnerLocation<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<Avalonia.Controls.Location>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Location>> ObserveBindingButtonSpinnerLocation(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingButtonSpinnerLocation<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<Avalonia.Controls.Location>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveButtonSpinnerLocationChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnButtonSpinnerLocationChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ButtonSpinnerLocationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -324,6 +420,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowButtonSpinner(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowButtonSpinner<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowButtonSpinnerChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowButtonSpinnerChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ShowButtonSpinnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty
 
     /// <summary>
@@ -418,6 +562,54 @@ public static partial class NumericUpDownExtensions
     public static T OnClipValueToMinMax<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingClipValueToMinMax(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClipValueToMinMax<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClipValueToMinMaxChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClipValueToMinMaxChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ClipValueToMinMaxProperty);
         handler(obj, observable);
         return obj;
     }
@@ -520,6 +712,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.NumberFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Globalization.NumberFormatInfo>> ObserveBindingNumberFormat(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.NumberFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.NumberFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingNumberFormat<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Globalization.NumberFormatInfo>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.NumberFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.NumberFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveNumberFormatChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.NumberFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.NumberFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnNumberFormatChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.NumberFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.FormatStringProperty
 
     /// <summary>
@@ -614,6 +854,54 @@ public static partial class NumericUpDownExtensions
     public static T OnFormatString<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<System.String>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.FormatStringProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.FormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingFormatString(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.FormatStringProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.FormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFormatString<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.FormatStringProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.FormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFormatStringChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.FormatStringProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.FormatStringProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFormatStringChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.FormatStringProperty);
         handler(obj, observable);
         return obj;
     }
@@ -716,6 +1004,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.IncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Decimal>> ObserveBindingIncrement(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.IncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.IncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIncrement<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Decimal>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.IncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.IncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIncrementChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.IncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.IncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIncrementChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.IncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.IsReadOnlyProperty
 
     /// <summary>
@@ -810,6 +1146,54 @@ public static partial class NumericUpDownExtensions
     public static T OnIsReadOnly<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsReadOnly(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsReadOnly<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsReadOnlyChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsReadOnlyChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.IsReadOnlyProperty);
         handler(obj, observable);
         return obj;
     }
@@ -912,6 +1296,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Decimal>> ObserveBindingMaximum(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaximum<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Decimal>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaximumChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaximumChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.MinimumProperty
 
     /// <summary>
@@ -1010,6 +1442,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Decimal>> ObserveBindingMinimum(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinimum<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Decimal>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinimumChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinimumChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty
 
     /// <summary>
@@ -1104,6 +1584,54 @@ public static partial class NumericUpDownExtensions
     public static T OnParsingNumberStyle<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<System.Globalization.NumberStyles>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Globalization.NumberStyles>> ObserveBindingParsingNumberStyle(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingParsingNumberStyle<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Globalization.NumberStyles>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveParsingNumberStyleChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnParsingNumberStyleChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ParsingNumberStyleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1434,6 +1962,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.TextConverterProperty
 
     /// <summary>
@@ -1528,6 +2104,54 @@ public static partial class NumericUpDownExtensions
     public static T OnTextConverter<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<Avalonia.Data.Converters.IValueConverter>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.TextConverterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.TextConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Data.Converters.IValueConverter>> ObserveBindingTextConverter(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.TextConverterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.TextConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextConverter<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<Avalonia.Data.Converters.IValueConverter>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.TextConverterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.TextConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextConverterChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.TextConverterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.TextConverterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextConverterChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.TextConverterProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1630,6 +2254,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.Decimal>>> ObserveBindingValue(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingValue<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Nullable<System.Decimal>>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveValueChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnValueChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.WatermarkProperty
 
     /// <summary>
@@ -1728,6 +2400,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingWatermark(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWatermark<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWatermarkChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWatermarkChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -1822,6 +2542,54 @@ public static partial class NumericUpDownExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1973,6 +2741,54 @@ public static partial class NumericUpDownExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.NumericUpDown.VerticalContentAlignmentProperty"/> property value to <see cref="Avalonia.Layout.VerticalAlignment.Stretch"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -2118,6 +2934,54 @@ public static partial class NumericUpDownExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingInnerLeftContent(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.InnerLeftContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInnerLeftContent<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.InnerLeftContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInnerLeftContentChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.InnerLeftContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInnerLeftContentChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.InnerLeftContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.NumericUpDown.InnerRightContentProperty
 
     /// <summary>
@@ -2212,6 +3076,54 @@ public static partial class NumericUpDownExtensions
     public static T OnInnerRightContent<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<System.Object>> handler) where T : Avalonia.Controls.NumericUpDown
     {
         var observable = obj.GetObservable(Avalonia.Controls.NumericUpDown.InnerRightContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.NumericUpDown.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingInnerRightContent(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.InnerRightContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.NumericUpDown.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInnerRightContent<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.NumericUpDown.InnerRightContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.NumericUpDown.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInnerRightContentChanged(this Avalonia.Controls.NumericUpDown obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.InnerRightContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.NumericUpDown.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInnerRightContentChanged<T>(this T obj, Action<Avalonia.Controls.NumericUpDown, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.NumericUpDown
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.NumericUpDown.InnerRightContentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/OverlayPopupHost.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/OverlayPopupHost.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class OverlayPopupHostExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Transform>> ObserveBindingTransform(this Avalonia.Controls.Primitives.OverlayPopupHost obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransform<T>(this T obj, Action<Avalonia.Controls.Primitives.OverlayPopupHost, IObservable<BindingValue<Avalonia.Media.Transform>>> handler) where T : Avalonia.Controls.Primitives.OverlayPopupHost
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransformChanged(this Avalonia.Controls.Primitives.OverlayPopupHost obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransformChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.OverlayPopupHost, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.OverlayPopupHost
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.OverlayPopupHost.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Panel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Panel.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class PanelExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Panel.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.Panel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Panel.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Panel.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.Panel, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Panel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Panel.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Panel.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.Panel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Panel.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Panel.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Panel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Panel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Panel.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Path.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Path.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class PathExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Path.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingData(this Avalonia.Controls.Shapes.Path obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Path.DataProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Path.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingData<T>(this T obj, Action<Avalonia.Controls.Shapes.Path, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler) where T : Avalonia.Controls.Shapes.Path
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Path.DataProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Path.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDataChanged(this Avalonia.Controls.Shapes.Path obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Path.DataProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Path.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDataChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Path, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Path
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Path.DataProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/PathFigure.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PathFigure.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class PathFigureExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathFigure.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsClosed(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathFigure.IsClosedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathFigure.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnBindingIsClosed(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathFigure.IsClosedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathFigure.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsClosedChanged(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.IsClosedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathFigure.IsClosedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnIsClosedChanged(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.IsClosedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.PathFigure.IsFilledProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class PathFigureExtensions
     public static Avalonia.Media.PathFigure OnIsFilled(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.PathFigure.IsFilledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathFigure.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsFilled(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathFigure.IsFilledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathFigure.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnBindingIsFilled(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathFigure.IsFilledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathFigure.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsFilledChanged(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.IsFilledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathFigure.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnIsFilledChanged(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.IsFilledProperty);
         handler(obj, observable);
         return obj;
     }
@@ -285,6 +377,52 @@ public static partial class PathFigureExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathFigure.SegmentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PathSegments>> ObserveBindingSegments(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathFigure.SegmentsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathFigure.SegmentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnBindingSegments(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<BindingValue<Avalonia.Media.PathSegments>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathFigure.SegmentsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathFigure.SegmentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSegmentsChanged(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.SegmentsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathFigure.SegmentsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnSegmentsChanged(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.SegmentsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.PathFigure.StartPointProperty
 
     /// <summary>
@@ -374,6 +512,52 @@ public static partial class PathFigureExtensions
     public static Avalonia.Media.PathFigure OnStartPoint(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<Avalonia.Point>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.PathFigure.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathFigure.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingStartPoint(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathFigure.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathFigure.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnBindingStartPoint(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathFigure.StartPointProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathFigure.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStartPointChanged(this Avalonia.Media.PathFigure obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.StartPointProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathFigure.StartPointProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PathFigure OnStartPointChanged(this Avalonia.Media.PathFigure obj, Action<Avalonia.Media.PathFigure, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathFigure.StartPointProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/PathGeometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PathGeometry.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class PathGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathGeometry.FiguresProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PathFigures>> ObserveBindingFigures(this Avalonia.Media.PathGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathGeometry.FiguresProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathGeometry.FiguresProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFigures<T>(this T obj, Action<Avalonia.Media.PathGeometry, IObservable<BindingValue<Avalonia.Media.PathFigures>>> handler) where T : Avalonia.Media.PathGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathGeometry.FiguresProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathGeometry.FiguresProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFiguresChanged(this Avalonia.Media.PathGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathGeometry.FiguresProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathGeometry.FiguresProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFiguresChanged<T>(this T obj, Action<Avalonia.Media.PathGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.PathGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathGeometry.FiguresProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.PathGeometry.FillRuleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class PathGeometryExtensions
     public static T OnFillRule<T>(this T obj, Action<Avalonia.Media.PathGeometry, IObservable<Avalonia.Media.FillRule>> handler) where T : Avalonia.Media.PathGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.PathGeometry.FillRuleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathGeometry.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FillRule>> ObserveBindingFillRule(this Avalonia.Media.PathGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathGeometry.FillRuleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathGeometry.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFillRule<T>(this T obj, Action<Avalonia.Media.PathGeometry, IObservable<BindingValue<Avalonia.Media.FillRule>>> handler) where T : Avalonia.Media.PathGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathGeometry.FillRuleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathGeometry.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFillRuleChanged(this Avalonia.Media.PathGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathGeometry.FillRuleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathGeometry.FillRuleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFillRuleChanged<T>(this T obj, Action<Avalonia.Media.PathGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.PathGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathGeometry.FillRuleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/PathIcon.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PathIcon.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class PathIconExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.PathIcon.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingData(this Avalonia.Controls.PathIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.PathIcon.DataProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.PathIcon.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingData<T>(this T obj, Action<Avalonia.Controls.PathIcon, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler) where T : Avalonia.Controls.PathIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.PathIcon.DataProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.PathIcon.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDataChanged(this Avalonia.Controls.PathIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.PathIcon.DataProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.PathIcon.DataProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDataChanged<T>(this T obj, Action<Avalonia.Controls.PathIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.PathIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.PathIcon.DataProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/PathSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PathSegment.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class PathSegmentExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PathSegment.IsStrokedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsStroked(this Avalonia.Media.PathSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PathSegment.IsStrokedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PathSegment.IsStrokedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsStroked<T>(this T obj, Action<Avalonia.Media.PathSegment, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Media.PathSegment
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PathSegment.IsStrokedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PathSegment.IsStrokedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsStrokedChanged(this Avalonia.Media.PathSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PathSegment.IsStrokedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PathSegment.IsStrokedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsStrokedChanged<T>(this T obj, Action<Avalonia.Media.PathSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.PathSegment
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PathSegment.IsStrokedProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Pen.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Pen.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class PenExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Pen.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBrush(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Pen.BrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Pen.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBindingBrush(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Pen.BrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Pen.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBrushChanged(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Pen.BrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Pen.BrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBrushChanged(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Pen.BrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Pen.ThicknessProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class PenExtensions
     public static Avalonia.Media.Pen OnThickness(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.Pen.ThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Pen.ThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingThickness(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Pen.ThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Pen.ThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBindingThickness(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Pen.ThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Pen.ThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveThicknessChanged(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Pen.ThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Pen.ThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnThicknessChanged(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Pen.ThicknessProperty);
         handler(obj, observable);
         return obj;
     }
@@ -285,6 +377,52 @@ public static partial class PenExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Pen.DashStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IDashStyle>> ObserveBindingDashStyle(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Pen.DashStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Pen.DashStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBindingDashStyle(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<BindingValue<Avalonia.Media.IDashStyle>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Pen.DashStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Pen.DashStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDashStyleChanged(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Pen.DashStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Pen.DashStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnDashStyleChanged(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Pen.DashStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Pen.LineCapProperty
 
     /// <summary>
@@ -374,6 +512,52 @@ public static partial class PenExtensions
     public static Avalonia.Media.Pen OnLineCap(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<Avalonia.Media.PenLineCap>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.Pen.LineCapProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Pen.LineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PenLineCap>> ObserveBindingLineCap(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Pen.LineCapProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Pen.LineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBindingLineCap(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<BindingValue<Avalonia.Media.PenLineCap>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Pen.LineCapProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Pen.LineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLineCapChanged(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Pen.LineCapProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Pen.LineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnLineCapChanged(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Pen.LineCapProperty);
         handler(obj, observable);
         return obj;
     }
@@ -505,6 +689,52 @@ public static partial class PenExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Pen.LineJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PenLineJoin>> ObserveBindingLineJoin(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Pen.LineJoinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Pen.LineJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBindingLineJoin(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<BindingValue<Avalonia.Media.PenLineJoin>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Pen.LineJoinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Pen.LineJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLineJoinChanged(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Pen.LineJoinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Pen.LineJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnLineJoinChanged(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Pen.LineJoinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Media.Pen.LineJoinProperty"/> property value to <see cref="Avalonia.Media.PenLineJoin.Bevel"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -626,6 +856,52 @@ public static partial class PenExtensions
     public static Avalonia.Media.Pen OnMiterLimit(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.Pen.MiterLimitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Pen.MiterLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMiterLimit(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Pen.MiterLimitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Pen.MiterLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnBindingMiterLimit(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Pen.MiterLimitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Pen.MiterLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMiterLimitChanged(this Avalonia.Media.Pen obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Pen.MiterLimitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Pen.MiterLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Pen OnMiterLimitChanged(this Avalonia.Media.Pen obj, Action<Avalonia.Media.Pen, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Pen.MiterLimitProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/PolyBezierSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PolyBezierSegment.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class PolyBezierSegmentExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PolyBezierSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Points>> ObserveBindingPoints(this Avalonia.Media.PolyBezierSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PolyBezierSegment.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PolyBezierSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PolyBezierSegment OnBindingPoints(this Avalonia.Media.PolyBezierSegment obj, Action<Avalonia.Media.PolyBezierSegment, IObservable<BindingValue<Avalonia.Points>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PolyBezierSegment.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PolyBezierSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointsChanged(this Avalonia.Media.PolyBezierSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PolyBezierSegment.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PolyBezierSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PolyBezierSegment OnPointsChanged(this Avalonia.Media.PolyBezierSegment obj, Action<Avalonia.Media.PolyBezierSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PolyBezierSegment.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/PolyLineSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PolyLineSegment.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class PolyLineSegmentExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PolyLineSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>> ObserveBindingPoints(this Avalonia.Media.PolyLineSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PolyLineSegment.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PolyLineSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PolyLineSegment OnBindingPoints(this Avalonia.Media.PolyLineSegment obj, Action<Avalonia.Media.PolyLineSegment, IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PolyLineSegment.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PolyLineSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointsChanged(this Avalonia.Media.PolyLineSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PolyLineSegment.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PolyLineSegment.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.PolyLineSegment OnPointsChanged(this Avalonia.Media.PolyLineSegment obj, Action<Avalonia.Media.PolyLineSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PolyLineSegment.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Polygon.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Polygon.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class PolygonExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Polygon.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>> ObserveBindingPoints(this Avalonia.Controls.Shapes.Polygon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Polygon.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Polygon.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPoints<T>(this T obj, Action<Avalonia.Controls.Shapes.Polygon, IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>>> handler) where T : Avalonia.Controls.Shapes.Polygon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Polygon.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Polygon.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointsChanged(this Avalonia.Controls.Shapes.Polygon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Polygon.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Polygon.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPointsChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Polygon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Polygon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Polygon.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Polyline.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Polyline.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class PolylineExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Polyline.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>> ObserveBindingPoints(this Avalonia.Controls.Shapes.Polyline obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Polyline.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Polyline.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPoints<T>(this T obj, Action<Avalonia.Controls.Shapes.Polyline, IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>>> handler) where T : Avalonia.Controls.Shapes.Polyline
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Polyline.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Polyline.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointsChanged(this Avalonia.Controls.Shapes.Polyline obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Polyline.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Polyline.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPointsChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Polyline, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Polyline
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Polyline.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/PolylineGeometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PolylineGeometry.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class PolylineGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PolylineGeometry.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>> ObserveBindingPoints(this Avalonia.Media.PolylineGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PolylineGeometry.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PolylineGeometry.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPoints<T>(this T obj, Action<Avalonia.Media.PolylineGeometry, IObservable<BindingValue<System.Collections.Generic.IList<Avalonia.Point>>>> handler) where T : Avalonia.Media.PolylineGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PolylineGeometry.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PolylineGeometry.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointsChanged(this Avalonia.Media.PolylineGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PolylineGeometry.PointsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PolylineGeometry.PointsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPointsChanged<T>(this T obj, Action<Avalonia.Media.PolylineGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.PolylineGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PolylineGeometry.PointsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.PolylineGeometry.IsFilledProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class PolylineGeometryExtensions
     public static T OnIsFilled<T>(this T obj, Action<Avalonia.Media.PolylineGeometry, IObservable<System.Boolean>> handler) where T : Avalonia.Media.PolylineGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.PolylineGeometry.IsFilledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.PolylineGeometry.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsFilled(this Avalonia.Media.PolylineGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.PolylineGeometry.IsFilledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.PolylineGeometry.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsFilled<T>(this T obj, Action<Avalonia.Media.PolylineGeometry, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Media.PolylineGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.PolylineGeometry.IsFilledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.PolylineGeometry.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsFilledChanged(this Avalonia.Media.PolylineGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.PolylineGeometry.IsFilledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.PolylineGeometry.IsFilledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsFilledChanged<T>(this T obj, Action<Avalonia.Media.PolylineGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.PolylineGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.PolylineGeometry.IsFilledProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Popup.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Popup.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingWindowManagerAddShadowHint(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWindowManagerAddShadowHint<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWindowManagerAddShadowHintChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWindowManagerAddShadowHintChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.WindowManagerAddShadowHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.ChildProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class PopupExtensions
     public static T OnChild<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<Avalonia.Controls.Control>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingChild(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingChild<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnChildChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.ChildProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.InheritsTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingInheritsTransform(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.InheritsTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.InheritsTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInheritsTransform<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.InheritsTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.InheritsTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInheritsTransformChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.InheritsTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.InheritsTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInheritsTransformChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.InheritsTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.IsOpenProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsOpen(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsOpen<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsOpenChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsOpenChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class PopupExtensions
     public static T OnPlacementAnchor<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>> ObserveBindingPlacementAnchor(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementAnchor<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementAnchorChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementAnchorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementAnchorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -739,6 +979,54 @@ public static partial class PopupExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>> ObserveBindingPlacementConstraintAdjustment(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementConstraintAdjustment<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementConstraintAdjustmentChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementConstraintAdjustmentChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.Popup.PlacementConstraintAdjustmentProperty"/> property value to <see cref="Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -928,6 +1216,54 @@ public static partial class PopupExtensions
     public static T OnPlacementGravity<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.PlacementGravityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>> ObserveBindingPlacementGravity(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementGravityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementGravity<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementGravityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementGravityChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementGravityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementGravityChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementGravityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1134,6 +1470,54 @@ public static partial class PopupExtensions
     public static T OnPlacement<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<Avalonia.Controls.PlacementMode>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.PlacementMode>> ObserveBindingPlacement(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacement<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.PlacementMode>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1428,6 +1812,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<Avalonia.Rect>>> ObserveBindingPlacementRect(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementRect<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Nullable<Avalonia.Rect>>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementRectChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementRectChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.PlacementTargetProperty
 
     /// <summary>
@@ -1522,6 +1954,54 @@ public static partial class PopupExtensions
     public static T OnPlacementTarget<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<Avalonia.Controls.Control>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.PlacementTargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingPlacementTarget(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementTargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementTarget<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.PlacementTargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementTargetChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementTargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.PlacementTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementTargetChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.PlacementTargetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1624,6 +2104,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>> ObserveBindingCustomPopupPlacementCallback(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCustomPopupPlacementCallback<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCustomPopupPlacementCallbackChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCustomPopupPlacementCallbackChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty
 
     /// <summary>
@@ -1718,6 +2246,54 @@ public static partial class PopupExtensions
     public static T OnOverlayDismissEventPassThrough<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingOverlayDismissEventPassThrough(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOverlayDismissEventPassThrough<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOverlayDismissEventPassThroughChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOverlayDismissEventPassThroughChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.OverlayDismissEventPassThroughProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1820,6 +2396,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.IInputElement>> ObserveBindingOverlayInputPassThroughElement(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOverlayInputPassThroughElement<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<Avalonia.Input.IInputElement>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOverlayInputPassThroughElementChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOverlayInputPassThroughElementChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.OverlayInputPassThroughElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty
 
     /// <summary>
@@ -1914,6 +2538,54 @@ public static partial class PopupExtensions
     public static T OnHorizontalOffset<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<System.Double>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalOffset(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalOffset<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalOffsetChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.HorizontalOffsetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2016,6 +2688,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsLightDismissEnabled(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsLightDismissEnabled<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsLightDismissEnabledChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsLightDismissEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.IsLightDismissEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty
 
     /// <summary>
@@ -2110,6 +2830,54 @@ public static partial class PopupExtensions
     public static T OnVerticalOffset<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<System.Double>> handler) where T : Avalonia.Controls.Primitives.Popup
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalOffset(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalOffset<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalOffsetChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.VerticalOffsetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2212,6 +2980,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingTopmost(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.TopmostProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTopmost<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.TopmostProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTopmostChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.TopmostProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTopmostChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.TopmostProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty
 
     /// <summary>
@@ -2306,6 +3122,54 @@ public static partial class PopupExtensions
     public static T OnTakesFocusFromNativeControl<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingTakesFocusFromNativeControl(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTakesFocusFromNativeControl<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTakesFocusFromNativeControlChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTakesFocusFromNativeControlChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.TakesFocusFromNativeControlProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2408,6 +3272,54 @@ public static partial class PopupExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShouldUseOverlayLayer(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShouldUseOverlayLayer<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShouldUseOverlayLayerChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShouldUseOverlayLayerChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Popup
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.ShouldUseOverlayLayerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty
 
     /// <summary>
@@ -2448,6 +3360,52 @@ public static partial class PopupExtensions
     public static Avalonia.Controls.Primitives.Popup OnIsUsingOverlayLayer(this Avalonia.Controls.Primitives.Popup obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsUsingOverlayLayer(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.Popup OnBindingIsUsingOverlayLayer(this Avalonia.Controls.Primitives.Popup obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsUsingOverlayLayerChanged(this Avalonia.Controls.Primitives.Popup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.Popup OnIsUsingOverlayLayerChanged(this Avalonia.Controls.Primitives.Popup obj, Action<Avalonia.Controls.Primitives.Popup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Popup.IsUsingOverlayLayerProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/PopupFlyoutBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PopupFlyoutBase.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class PopupFlyoutBaseExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.PlacementMode>> ObserveBindingPlacement(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacement<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Controls.PlacementMode>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementProperty"/> property value to <see cref="Avalonia.Controls.PlacementMode.Pointer"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -394,6 +442,54 @@ public static partial class PopupFlyoutBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalOffset(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalOffset<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalOffsetChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty
 
     /// <summary>
@@ -492,6 +588,54 @@ public static partial class PopupFlyoutBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalOffset(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalOffset<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalOffsetChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty
 
     /// <summary>
@@ -586,6 +730,54 @@ public static partial class PopupFlyoutBaseExtensions
     public static T OnPlacementAnchor<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>> ObserveBindingPlacementAnchor(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementAnchor<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementAnchorChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementAnchorChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementAnchorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -833,6 +1025,54 @@ public static partial class PopupFlyoutBaseExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>> ObserveBindingPlacementGravity(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementGravity<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupGravity>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementGravityChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementGravityChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementGravityProperty"/> property value to <see cref="Avalonia.Controls.Primitives.PopupPositioning.PopupGravity.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1038,6 +1278,54 @@ public static partial class PopupFlyoutBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>> ObserveBindingCustomPopupPlacementCallback(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCustomPopupPlacementCallback<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCustomPopupPlacementCallbackChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCustomPopupPlacementCallbackChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty
 
     /// <summary>
@@ -1132,6 +1420,54 @@ public static partial class PopupFlyoutBaseExtensions
     public static T OnShowMode<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<Avalonia.Controls.FlyoutShowMode>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.FlyoutShowMode>> ObserveBindingShowMode(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowMode<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Controls.FlyoutShowMode>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowModeChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowModeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.ShowModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1270,6 +1606,54 @@ public static partial class PopupFlyoutBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingOverlayDismissEventPassThrough(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOverlayDismissEventPassThrough<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOverlayDismissEventPassThroughChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOverlayDismissEventPassThroughChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayDismissEventPassThroughProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty
 
     /// <summary>
@@ -1368,6 +1752,54 @@ public static partial class PopupFlyoutBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.IInputElement>> ObserveBindingOverlayInputPassThroughElement(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOverlayInputPassThroughElement<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Input.IInputElement>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOverlayInputPassThroughElementChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOverlayInputPassThroughElementChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.OverlayInputPassThroughElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty
 
     /// <summary>
@@ -1462,6 +1894,54 @@ public static partial class PopupFlyoutBaseExtensions
     public static T OnPlacementConstraintAdjustment<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>> ObserveBindingPlacementConstraintAdjustment(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacementConstraintAdjustment<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.PopupPositionerConstraintAdjustment>>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementConstraintAdjustmentChanged(this Avalonia.Controls.Primitives.PopupFlyoutBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementConstraintAdjustmentChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.PopupFlyoutBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.PopupFlyoutBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupFlyoutBase.PlacementConstraintAdjustmentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/PopupRoot.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PopupRoot.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class PopupRootExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Transform>> ObserveBindingTransform(this Avalonia.Controls.Primitives.PopupRoot obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupRoot.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.PopupRoot OnBindingTransform(this Avalonia.Controls.Primitives.PopupRoot obj, Action<Avalonia.Controls.Primitives.PopupRoot, IObservable<BindingValue<Avalonia.Media.Transform>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupRoot.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransformChanged(this Avalonia.Controls.Primitives.PopupRoot obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupRoot.TransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.TransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.PopupRoot OnTransformChanged(this Avalonia.Controls.Primitives.PopupRoot obj, Action<Avalonia.Controls.Primitives.PopupRoot, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupRoot.TransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class PopupRootExtensions
     public static Avalonia.Controls.Primitives.PopupRoot OnWindowManagerAddShadowHint(this Avalonia.Controls.Primitives.PopupRoot obj, Action<Avalonia.Controls.Primitives.PopupRoot, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingWindowManagerAddShadowHint(this Avalonia.Controls.Primitives.PopupRoot obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.PopupRoot OnBindingWindowManagerAddShadowHint(this Avalonia.Controls.Primitives.PopupRoot obj, Action<Avalonia.Controls.Primitives.PopupRoot, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWindowManagerAddShadowHintChanged(this Avalonia.Controls.Primitives.PopupRoot obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Controls.Primitives.PopupRoot OnWindowManagerAddShadowHintChanged(this Avalonia.Controls.Primitives.PopupRoot obj, Action<Avalonia.Controls.Primitives.PopupRoot, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.PopupRoot.WindowManagerAddShadowHintProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ProgressBar.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ProgressBar.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ProgressBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ProgressBar.IsIndeterminateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsIndeterminate(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ProgressBar.IsIndeterminateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ProgressBar.IsIndeterminateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsIndeterminate<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ProgressBar.IsIndeterminateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ProgressBar.IsIndeterminateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsIndeterminateChanged(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.IsIndeterminateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ProgressBar.IsIndeterminateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsIndeterminateChanged<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.IsIndeterminateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ProgressBar.ShowProgressTextProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ProgressBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ProgressBar.ShowProgressTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowProgressText(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ProgressBar.ShowProgressTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ProgressBar.ShowProgressTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowProgressText<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ProgressBar.ShowProgressTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ProgressBar.ShowProgressTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowProgressTextChanged(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.ShowProgressTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ProgressBar.ShowProgressTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowProgressTextChanged<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.ShowProgressTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ProgressBar.ProgressTextFormatProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ProgressBarExtensions
     public static T OnProgressTextFormat<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<System.String>> handler) where T : Avalonia.Controls.ProgressBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.ProgressBar.ProgressTextFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ProgressBar.ProgressTextFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingProgressTextFormat(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ProgressBar.ProgressTextFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ProgressBar.ProgressTextFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingProgressTextFormat<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ProgressBar.ProgressTextFormatProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ProgressBar.ProgressTextFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveProgressTextFormatChanged(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.ProgressTextFormatProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ProgressBar.ProgressTextFormatProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnProgressTextFormatChanged<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.ProgressTextFormatProperty);
         handler(obj, observable);
         return obj;
     }
@@ -399,6 +543,54 @@ public static partial class ProgressBarExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ProgressBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ProgressBar.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ProgressBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ProgressBar.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ProgressBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ProgressBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.ProgressBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ProgressBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ProgressBar.OrientationProperty"/> property value to <see cref="Avalonia.Layout.Orientation.Horizontal"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -462,6 +654,52 @@ public static partial class ProgressBarExtensions
     public static Avalonia.Controls.ProgressBar OnPercentage(this Avalonia.Controls.ProgressBar obj, Action<Avalonia.Controls.ProgressBar, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ProgressBar.PercentageProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ProgressBar.PercentageProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingPercentage(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ProgressBar.PercentageProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ProgressBar.PercentageProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ProgressBar OnBindingPercentage(this Avalonia.Controls.ProgressBar obj, Action<Avalonia.Controls.ProgressBar, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ProgressBar.PercentageProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ProgressBar.PercentageProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePercentageChanged(this Avalonia.Controls.ProgressBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.PercentageProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ProgressBar.PercentageProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ProgressBar OnPercentageChanged(this Avalonia.Controls.ProgressBar obj, Action<Avalonia.Controls.ProgressBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ProgressBar.PercentageProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/PullGestureRecognizer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/PullGestureRecognizer.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class PullGestureRecognizerExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.PullGestureRecognizer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.PullDirection>> ObserveBindingPullDirection(this Avalonia.Input.PullGestureRecognizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.PullGestureRecognizer.PullDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.PullGestureRecognizer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPullDirection<T>(this T obj, Action<Avalonia.Input.PullGestureRecognizer, IObservable<BindingValue<Avalonia.Input.PullDirection>>> handler) where T : Avalonia.Input.PullGestureRecognizer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.PullGestureRecognizer.PullDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.PullGestureRecognizer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePullDirectionChanged(this Avalonia.Input.PullGestureRecognizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.PullGestureRecognizer.PullDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.PullGestureRecognizer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPullDirectionChanged<T>(this T obj, Action<Avalonia.Input.PullGestureRecognizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.PullGestureRecognizer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.PullGestureRecognizer.PullDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Input.PullGestureRecognizer.PullDirectionProperty"/> property value to <see cref="Avalonia.Input.PullDirection.TopToBottom"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>

--- a/src/NXUI/Generated/Extensions/QuadraticBezierSegment.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/QuadraticBezierSegment.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class QuadraticBezierSegmentExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint1(this Avalonia.Media.QuadraticBezierSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.QuadraticBezierSegment.Point1Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.QuadraticBezierSegment OnBindingPoint1(this Avalonia.Media.QuadraticBezierSegment obj, Action<Avalonia.Media.QuadraticBezierSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.QuadraticBezierSegment.Point1Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePoint1Changed(this Avalonia.Media.QuadraticBezierSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.QuadraticBezierSegment.Point1Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point1Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.QuadraticBezierSegment OnPoint1Changed(this Avalonia.Media.QuadraticBezierSegment obj, Action<Avalonia.Media.QuadraticBezierSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.QuadraticBezierSegment.Point1Property);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.QuadraticBezierSegment.Point2Property
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class QuadraticBezierSegmentExtensions
     public static Avalonia.Media.QuadraticBezierSegment OnPoint2(this Avalonia.Media.QuadraticBezierSegment obj, Action<Avalonia.Media.QuadraticBezierSegment, IObservable<Avalonia.Point>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.QuadraticBezierSegment.Point2Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Point>> ObserveBindingPoint2(this Avalonia.Media.QuadraticBezierSegment obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.QuadraticBezierSegment.Point2Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.QuadraticBezierSegment OnBindingPoint2(this Avalonia.Media.QuadraticBezierSegment obj, Action<Avalonia.Media.QuadraticBezierSegment, IObservable<BindingValue<Avalonia.Point>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.QuadraticBezierSegment.Point2Property);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePoint2Changed(this Avalonia.Media.QuadraticBezierSegment obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.QuadraticBezierSegment.Point2Property);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.QuadraticBezierSegment.Point2Property"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.QuadraticBezierSegment OnPoint2Changed(this Avalonia.Media.QuadraticBezierSegment obj, Action<Avalonia.Media.QuadraticBezierSegment, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.QuadraticBezierSegment.Point2Property);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RadialGradientBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RadialGradientBrush.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class RadialGradientBrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingCenter(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.CenterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnBindingCenter(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<BindingValue<Avalonia.RelativePoint>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.CenterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RadialGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterChanged(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.CenterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RadialGradientBrush.CenterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnCenterChanged(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.CenterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.RadialGradientBrush.GradientOriginProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class RadialGradientBrushExtensions
     public static Avalonia.Media.RadialGradientBrush OnGradientOrigin(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<Avalonia.RelativePoint>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.RadialGradientBrush.GradientOriginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.GradientOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingGradientOrigin(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.GradientOriginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.GradientOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnBindingGradientOrigin(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<BindingValue<Avalonia.RelativePoint>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.GradientOriginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RadialGradientBrush.GradientOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGradientOriginChanged(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.GradientOriginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RadialGradientBrush.GradientOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnGradientOriginChanged(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.GradientOriginProperty);
         handler(obj, observable);
         return obj;
     }
@@ -285,6 +377,52 @@ public static partial class RadialGradientBrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativeScalar>> ObserveBindingRadiusX(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnBindingRadiusX(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<BindingValue<Avalonia.RelativeScalar>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusXChanged(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnRadiusXChanged(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.RadialGradientBrush.RadiusYProperty
 
     /// <summary>
@@ -374,6 +512,52 @@ public static partial class RadialGradientBrushExtensions
     public static Avalonia.Media.RadialGradientBrush OnRadiusY(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<Avalonia.RelativeScalar>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.RadialGradientBrush.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativeScalar>> ObserveBindingRadiusY(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnBindingRadiusY(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<BindingValue<Avalonia.RelativeScalar>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RadialGradientBrush.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusYChanged(this Avalonia.Media.RadialGradientBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RadialGradientBrush.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RadialGradientBrush OnRadiusYChanged(this Avalonia.Media.RadialGradientBrush obj, Action<Avalonia.Media.RadialGradientBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RadialGradientBrush.RadiusYProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RadioButton.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RadioButton.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class RadioButtonExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RadioButton.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingGroupName(this Avalonia.Controls.RadioButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RadioButton.GroupNameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RadioButton.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingGroupName<T>(this T obj, Action<Avalonia.Controls.RadioButton, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.RadioButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RadioButton.GroupNameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RadioButton.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveGroupNameChanged(this Avalonia.Controls.RadioButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RadioButton.GroupNameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RadioButton.GroupNameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnGroupNameChanged<T>(this T obj, Action<Avalonia.Controls.RadioButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RadioButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RadioButton.GroupNameProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/RangeBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RangeBase.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RangeBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinimum(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinimum<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinimumChanged(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinimumChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.RangeBase.MaximumProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class RangeBaseExtensions
     public static T OnMaximum<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<System.Double>> handler) where T : Avalonia.Controls.Primitives.RangeBase
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.RangeBase.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaximum(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaximum<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaximumChanged(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaximumChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.MaximumProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class RangeBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingValue(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingValue<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveValueChanged(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class RangeBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSmallChange(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSmallChange<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSmallChangeChanged(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSmallChangeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.SmallChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class RangeBaseExtensions
     public static T OnLargeChange<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<System.Double>> handler) where T : Avalonia.Controls.Primitives.RangeBase
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingLargeChange(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLargeChange<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLargeChangeChanged(this Avalonia.Controls.Primitives.RangeBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLargeChangeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.RangeBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.RangeBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.RangeBase.LargeChangeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Rectangle.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Rectangle.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RectangleExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadiusX(this Avalonia.Controls.Shapes.Rectangle obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Rectangle.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRadiusX<T>(this T obj, Action<Avalonia.Controls.Shapes.Rectangle, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Rectangle
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Rectangle.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusXChanged(this Avalonia.Controls.Shapes.Rectangle obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Rectangle.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRadiusXChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Rectangle, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Rectangle
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Rectangle.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Rectangle.RadiusYProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class RectangleExtensions
     public static T OnRadiusY<T>(this T obj, Action<Avalonia.Controls.Shapes.Rectangle, IObservable<System.Double>> handler) where T : Avalonia.Controls.Shapes.Rectangle
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Rectangle.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadiusY(this Avalonia.Controls.Shapes.Rectangle obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Rectangle.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRadiusY<T>(this T obj, Action<Avalonia.Controls.Shapes.Rectangle, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Rectangle
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Rectangle.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusYChanged(this Avalonia.Controls.Shapes.Rectangle obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Rectangle.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Rectangle.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRadiusYChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Rectangle, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Rectangle
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Rectangle.RadiusYProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RectangleGeometry.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RectangleGeometry.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RectangleGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadiusX(this Avalonia.Media.RectangleGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RectangleGeometry.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRadiusX<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.RectangleGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RectangleGeometry.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusXChanged(this Avalonia.Media.RectangleGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RectangleGeometry.RadiusXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRadiusXChanged<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.RectangleGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RectangleGeometry.RadiusXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.RectangleGeometry.RadiusYProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class RectangleGeometryExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRadiusY(this Avalonia.Media.RectangleGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RectangleGeometry.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRadiusY<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.RectangleGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RectangleGeometry.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRadiusYChanged(this Avalonia.Media.RectangleGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RectangleGeometry.RadiusYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RectangleGeometry.RadiusYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRadiusYChanged<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.RectangleGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RectangleGeometry.RadiusYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.RectangleGeometry.RectProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class RectangleGeometryExtensions
     public static T OnRect<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<Avalonia.Rect>> handler) where T : Avalonia.Media.RectangleGeometry
     {
         var observable = obj.GetObservable(Avalonia.Media.RectangleGeometry.RectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RectangleGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Rect>> ObserveBindingRect(this Avalonia.Media.RectangleGeometry obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RectangleGeometry.RectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RectangleGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRect<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<BindingValue<Avalonia.Rect>>> handler) where T : Avalonia.Media.RectangleGeometry
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RectangleGeometry.RectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RectangleGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRectChanged(this Avalonia.Media.RectangleGeometry obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RectangleGeometry.RectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RectangleGeometry.RectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRectChanged<T>(this T obj, Action<Avalonia.Media.RectangleGeometry, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.RectangleGeometry
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RectangleGeometry.RectProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RefreshContainer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RefreshContainer.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RefreshContainerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RefreshContainer.VisualizerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.RefreshVisualizer>> ObserveBindingVisualizer(this Avalonia.Controls.RefreshContainer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RefreshContainer.VisualizerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RefreshContainer.VisualizerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVisualizer<T>(this T obj, Action<Avalonia.Controls.RefreshContainer, IObservable<BindingValue<Avalonia.Controls.RefreshVisualizer>>> handler) where T : Avalonia.Controls.RefreshContainer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RefreshContainer.VisualizerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RefreshContainer.VisualizerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVisualizerChanged(this Avalonia.Controls.RefreshContainer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshContainer.VisualizerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RefreshContainer.VisualizerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVisualizerChanged<T>(this T obj, Action<Avalonia.Controls.RefreshContainer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RefreshContainer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshContainer.VisualizerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RefreshContainer.PullDirectionProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class RefreshContainerExtensions
     public static T OnPullDirection<T>(this T obj, Action<Avalonia.Controls.RefreshContainer, IObservable<Avalonia.Input.PullDirection>> handler) where T : Avalonia.Controls.RefreshContainer
     {
         var observable = obj.GetObservable(Avalonia.Controls.RefreshContainer.PullDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RefreshContainer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.PullDirection>> ObserveBindingPullDirection(this Avalonia.Controls.RefreshContainer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RefreshContainer.PullDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RefreshContainer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPullDirection<T>(this T obj, Action<Avalonia.Controls.RefreshContainer, IObservable<BindingValue<Avalonia.Input.PullDirection>>> handler) where T : Avalonia.Controls.RefreshContainer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RefreshContainer.PullDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RefreshContainer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePullDirectionChanged(this Avalonia.Controls.RefreshContainer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshContainer.PullDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RefreshContainer.PullDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPullDirectionChanged<T>(this T obj, Action<Avalonia.Controls.RefreshContainer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RefreshContainer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshContainer.PullDirectionProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RefreshVisualizer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RefreshVisualizer.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class RefreshVisualizerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.RefreshVisualizerState>> ObserveBindingRefreshVisualizerState(this Avalonia.Controls.RefreshVisualizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.RefreshVisualizer OnBindingRefreshVisualizerState(this Avalonia.Controls.RefreshVisualizer obj, Action<Avalonia.Controls.RefreshVisualizer, IObservable<BindingValue<Avalonia.Controls.RefreshVisualizerState>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRefreshVisualizerStateChanged(this Avalonia.Controls.RefreshVisualizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.RefreshVisualizer OnRefreshVisualizerStateChanged(this Avalonia.Controls.RefreshVisualizer obj, Action<Avalonia.Controls.RefreshVisualizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshVisualizer.RefreshVisualizerStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RefreshVisualizer.OrientationProperty
 
     /// <summary>
@@ -144,6 +190,54 @@ public static partial class RefreshVisualizerExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Controls.RefreshVisualizer, IObservable<Avalonia.Controls.RefreshVisualizerOrientation>> handler) where T : Avalonia.Controls.RefreshVisualizer
     {
         var observable = obj.GetObservable(Avalonia.Controls.RefreshVisualizer.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RefreshVisualizer.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.RefreshVisualizerOrientation>> ObserveBindingOrientation(this Avalonia.Controls.RefreshVisualizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RefreshVisualizer.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RefreshVisualizer.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.RefreshVisualizer, IObservable<BindingValue<Avalonia.Controls.RefreshVisualizerOrientation>>> handler) where T : Avalonia.Controls.RefreshVisualizer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RefreshVisualizer.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RefreshVisualizer.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.RefreshVisualizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshVisualizer.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RefreshVisualizer.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.RefreshVisualizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RefreshVisualizer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RefreshVisualizer.OrientationProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RelativePanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RelativePanel.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AboveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingAbove(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AboveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AboveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAbove<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AboveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AboveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAboveChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AboveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AboveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAboveChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AboveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class RelativePanelExtensions
     public static T OnAlignBottomWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Boolean>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAlignBottomWithPanel(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignBottomWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignBottomWithPanelChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignBottomWithPanelChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignBottomWithPanelProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingAlignBottomWith(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignBottomWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignBottomWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignBottomWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignBottomWithChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignBottomWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignBottomWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignBottomWithChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignBottomWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class RelativePanelExtensions
     public static T OnAlignHorizontalCenterWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Boolean>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAlignHorizontalCenterWithPanel(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignHorizontalCenterWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignHorizontalCenterWithPanelChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignHorizontalCenterWithPanelChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignHorizontalCenterWithPanelProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAlignLeftWithPanel(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignLeftWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignLeftWithPanelChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignLeftWithPanelChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignLeftWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.AlignLeftWithProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class RelativePanelExtensions
     public static T OnAlignLeftWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Object>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.AlignLeftWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingAlignLeftWith(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignLeftWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignLeftWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignLeftWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignLeftWithChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignLeftWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignLeftWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignLeftWithChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignLeftWithProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAlignRightWithPanel(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignRightWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignRightWithPanelChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignRightWithPanelChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignRightWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.AlignRightWithProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class RelativePanelExtensions
     public static T OnAlignRightWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Object>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.AlignRightWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingAlignRightWith(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignRightWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignRightWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignRightWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignRightWithChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignRightWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignRightWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignRightWithChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignRightWithProperty);
         handler(obj, observable);
         return obj;
     }
@@ -888,6 +1272,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAlignTopWithPanel(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignTopWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignTopWithPanelChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignTopWithPanelChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignTopWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.AlignTopWithProperty
 
     /// <summary>
@@ -982,6 +1414,54 @@ public static partial class RelativePanelExtensions
     public static T OnAlignTopWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Object>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.AlignTopWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingAlignTopWith(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignTopWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignTopWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignTopWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignTopWithChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignTopWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignTopWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignTopWithChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignTopWithProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1084,6 +1564,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAlignVerticalCenterWithPanel(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignVerticalCenterWithPanel<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignVerticalCenterWithPanelChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignVerticalCenterWithPanelChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithPanelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty
 
     /// <summary>
@@ -1178,6 +1706,54 @@ public static partial class RelativePanelExtensions
     public static T OnAlignVerticalCenterWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Object>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingAlignVerticalCenterWith(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignVerticalCenterWith<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignVerticalCenterWithChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignVerticalCenterWithChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.AlignVerticalCenterWithProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1280,6 +1856,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.BelowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingBelow(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.BelowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.BelowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBelow<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.BelowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.BelowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBelowChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.BelowProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.BelowProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBelowChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.BelowProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.LeftOfProperty
 
     /// <summary>
@@ -1378,6 +2002,54 @@ public static partial class RelativePanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.LeftOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingLeftOf(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.LeftOfProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.LeftOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLeftOf<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.LeftOfProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.LeftOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLeftOfChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.LeftOfProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.LeftOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLeftOfChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.LeftOfProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RelativePanel.RightOfProperty
 
     /// <summary>
@@ -1472,6 +2144,54 @@ public static partial class RelativePanelExtensions
     public static T OnRightOf<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<System.Object>> handler) where T : Avalonia.Layout.Layoutable
     {
         var observable = obj.GetObservable(Avalonia.Controls.RelativePanel.RightOfProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RelativePanel.RightOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingRightOf(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RelativePanel.RightOfProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RelativePanel.RightOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRightOf<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RelativePanel.RightOfProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RelativePanel.RightOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRightOfChanged(this Avalonia.Layout.Layoutable obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.RightOfProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RelativePanel.RightOfProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRightOfChanged<T>(this T obj, Action<Avalonia.Layout.Layoutable, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.Layoutable
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RelativePanel.RightOfProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RepeatButton.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RepeatButton.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RepeatButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RepeatButton.IntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingInterval(this Avalonia.Controls.RepeatButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RepeatButton.IntervalProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RepeatButton.IntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInterval<T>(this T obj, Action<Avalonia.Controls.RepeatButton, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.RepeatButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RepeatButton.IntervalProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RepeatButton.IntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIntervalChanged(this Avalonia.Controls.RepeatButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RepeatButton.IntervalProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RepeatButton.IntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIntervalChanged<T>(this T obj, Action<Avalonia.Controls.RepeatButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RepeatButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RepeatButton.IntervalProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RepeatButton.DelayProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class RepeatButtonExtensions
     public static T OnDelay<T>(this T obj, Action<Avalonia.Controls.RepeatButton, IObservable<System.Int32>> handler) where T : Avalonia.Controls.RepeatButton
     {
         var observable = obj.GetObservable(Avalonia.Controls.RepeatButton.DelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RepeatButton.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingDelay(this Avalonia.Controls.RepeatButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RepeatButton.DelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RepeatButton.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDelay<T>(this T obj, Action<Avalonia.Controls.RepeatButton, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.RepeatButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RepeatButton.DelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RepeatButton.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDelayChanged(this Avalonia.Controls.RepeatButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RepeatButton.DelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RepeatButton.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDelayChanged<T>(this T obj, Action<Avalonia.Controls.RepeatButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RepeatButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RepeatButton.DelayProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ReversibleStackPanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ReversibleStackPanel.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class ReversibleStackPanelExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingReverseOrder(this Avalonia.Controls.ReversibleStackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingReverseOrder<T>(this T obj, Action<Avalonia.Controls.ReversibleStackPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ReversibleStackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveReverseOrderChanged(this Avalonia.Controls.ReversibleStackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnReverseOrderChanged<T>(this T obj, Action<Avalonia.Controls.ReversibleStackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ReversibleStackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ReversibleStackPanel.ReverseOrderProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Rotate3DTransform.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Rotate3DTransform.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class Rotate3DTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngleX(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.AngleXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingAngleX(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.AngleXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleXChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.AngleXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnAngleXChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.AngleXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Rotate3DTransform.AngleYProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class Rotate3DTransformExtensions
     public static Avalonia.Media.Rotate3DTransform OnAngleY(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.Rotate3DTransform.AngleYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngleY(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.AngleYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingAngleY(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.AngleYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleYChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.AngleYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnAngleYChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.AngleYProperty);
         handler(obj, observable);
         return obj;
     }
@@ -285,6 +377,52 @@ public static partial class Rotate3DTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngleZ(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.AngleZProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingAngleZ(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.AngleZProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleZChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.AngleZProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.AngleZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnAngleZChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.AngleZProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Rotate3DTransform.CenterXProperty
 
     /// <summary>
@@ -374,6 +512,52 @@ public static partial class Rotate3DTransformExtensions
     public static Avalonia.Media.Rotate3DTransform OnCenterX(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.Rotate3DTransform.CenterXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingCenterX(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.CenterXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingCenterX(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.CenterXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterXChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.CenterXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnCenterXChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.CenterXProperty);
         handler(obj, observable);
         return obj;
     }
@@ -471,6 +655,52 @@ public static partial class Rotate3DTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingCenterY(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.CenterYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingCenterY(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.CenterYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterYChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.CenterYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnCenterYChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.CenterYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Rotate3DTransform.CenterZProperty
 
     /// <summary>
@@ -564,6 +794,52 @@ public static partial class Rotate3DTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingCenterZ(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.CenterZProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingCenterZ(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.CenterZProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterZChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.CenterZProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.CenterZProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnCenterZChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.CenterZProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.Rotate3DTransform.DepthProperty
 
     /// <summary>
@@ -653,6 +929,52 @@ public static partial class Rotate3DTransformExtensions
     public static Avalonia.Media.Rotate3DTransform OnDepth(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.Rotate3DTransform.DepthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.DepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingDepth(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.DepthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.Rotate3DTransform.DepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnBindingDepth(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.Rotate3DTransform.DepthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.Rotate3DTransform.DepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDepthChanged(this Avalonia.Media.Rotate3DTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.DepthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.Rotate3DTransform.DepthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.Rotate3DTransform OnDepthChanged(this Avalonia.Media.Rotate3DTransform obj, Action<Avalonia.Media.Rotate3DTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.Rotate3DTransform.DepthProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RotateTransform.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RotateTransform.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class RotateTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RotateTransform.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngle(this Avalonia.Media.RotateTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RotateTransform.AngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RotateTransform.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RotateTransform OnBindingAngle(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RotateTransform.AngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RotateTransform.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleChanged(this Avalonia.Media.RotateTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RotateTransform.AngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RotateTransform.AngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RotateTransform OnAngleChanged(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RotateTransform.AngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.RotateTransform.CenterXProperty
 
     /// <summary>
@@ -192,6 +238,52 @@ public static partial class RotateTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RotateTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingCenterX(this Avalonia.Media.RotateTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RotateTransform.CenterXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RotateTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RotateTransform OnBindingCenterX(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RotateTransform.CenterXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RotateTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterXChanged(this Avalonia.Media.RotateTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RotateTransform.CenterXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RotateTransform.CenterXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RotateTransform OnCenterXChanged(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RotateTransform.CenterXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.RotateTransform.CenterYProperty
 
     /// <summary>
@@ -281,6 +373,52 @@ public static partial class RotateTransformExtensions
     public static Avalonia.Media.RotateTransform OnCenterY(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.RotateTransform.CenterYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.RotateTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingCenterY(this Avalonia.Media.RotateTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.RotateTransform.CenterYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.RotateTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RotateTransform OnBindingCenterY(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.RotateTransform.CenterYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.RotateTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCenterYChanged(this Avalonia.Media.RotateTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.RotateTransform.CenterYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.RotateTransform.CenterYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.RotateTransform OnCenterYChanged(this Avalonia.Media.RotateTransform obj, Action<Avalonia.Media.RotateTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.RotateTransform.CenterYProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/RowDefinition.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/RowDefinition.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class RowDefinitionExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RowDefinition.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaxHeight(this Avalonia.Controls.RowDefinition obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RowDefinition.MaxHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RowDefinition.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxHeight<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.RowDefinition
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RowDefinition.MaxHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RowDefinition.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxHeightChanged(this Avalonia.Controls.RowDefinition obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RowDefinition.MaxHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RowDefinition.MaxHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxHeightChanged<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RowDefinition
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RowDefinition.MaxHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RowDefinition.MinHeightProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class RowDefinitionExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RowDefinition.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinHeight(this Avalonia.Controls.RowDefinition obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RowDefinition.MinHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RowDefinition.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinHeight<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.RowDefinition
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RowDefinition.MinHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RowDefinition.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinHeightChanged(this Avalonia.Controls.RowDefinition obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RowDefinition.MinHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RowDefinition.MinHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinHeightChanged<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RowDefinition
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RowDefinition.MinHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.RowDefinition.HeightProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class RowDefinitionExtensions
     public static T OnHeight<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<Avalonia.Controls.GridLength>> handler) where T : Avalonia.Controls.RowDefinition
     {
         var observable = obj.GetObservable(Avalonia.Controls.RowDefinition.HeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.RowDefinition.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.GridLength>> ObserveBindingHeight(this Avalonia.Controls.RowDefinition obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.RowDefinition.HeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.RowDefinition.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHeight<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<BindingValue<Avalonia.Controls.GridLength>>> handler) where T : Avalonia.Controls.RowDefinition
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.RowDefinition.HeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.RowDefinition.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeightChanged(this Avalonia.Controls.RowDefinition obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.RowDefinition.HeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.RowDefinition.HeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHeightChanged<T>(this T obj, Action<Avalonia.Controls.RowDefinition, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.RowDefinition
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.RowDefinition.HeightProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Run.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Run.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class RunExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.Run.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.Documents.Run obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.Run.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.Run.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.Documents.Run, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Documents.Run
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.Run.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.Run.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.Documents.Run obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Run.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.Run.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.Documents.Run, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.Run
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Run.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/ScaleTransform.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ScaleTransform.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class ScaleTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ScaleTransform.ScaleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingScaleX(this Avalonia.Media.ScaleTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ScaleTransform.ScaleXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ScaleTransform.ScaleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ScaleTransform OnBindingScaleX(this Avalonia.Media.ScaleTransform obj, Action<Avalonia.Media.ScaleTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ScaleTransform.ScaleXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ScaleTransform.ScaleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveScaleXChanged(this Avalonia.Media.ScaleTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ScaleTransform.ScaleXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ScaleTransform.ScaleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ScaleTransform OnScaleXChanged(this Avalonia.Media.ScaleTransform obj, Action<Avalonia.Media.ScaleTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ScaleTransform.ScaleXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.ScaleTransform.ScaleYProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class ScaleTransformExtensions
     public static Avalonia.Media.ScaleTransform OnScaleY(this Avalonia.Media.ScaleTransform obj, Action<Avalonia.Media.ScaleTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.ScaleTransform.ScaleYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.ScaleTransform.ScaleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingScaleY(this Avalonia.Media.ScaleTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.ScaleTransform.ScaleYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.ScaleTransform.ScaleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ScaleTransform OnBindingScaleY(this Avalonia.Media.ScaleTransform obj, Action<Avalonia.Media.ScaleTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.ScaleTransform.ScaleYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.ScaleTransform.ScaleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveScaleYChanged(this Avalonia.Media.ScaleTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.ScaleTransform.ScaleYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.ScaleTransform.ScaleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.ScaleTransform OnScaleYChanged(this Avalonia.Media.ScaleTransform obj, Action<Avalonia.Media.ScaleTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.ScaleTransform.ScaleYProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ScrollBar.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ScrollBar.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ScrollBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingViewportSize(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingViewportSize<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveViewportSizeChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnViewportSizeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.ViewportSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ScrollBarExtensions
     public static T OnVisibility<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<Avalonia.Controls.Primitives.ScrollBarVisibility>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>> ObserveBindingVisibility(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVisibility<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVisibilityChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.VisibilityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -349,6 +445,54 @@ public static partial class ScrollBarExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.ScrollBar.OrientationProperty"/> property value to <see cref="Avalonia.Layout.Orientation.Horizontal"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -412,6 +556,52 @@ public static partial class ScrollBarExtensions
     public static Avalonia.Controls.Primitives.ScrollBar OnIsExpanded(this Avalonia.Controls.Primitives.ScrollBar obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsExpanded(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.ScrollBar OnBindingIsExpanded(this Avalonia.Controls.Primitives.ScrollBar obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsExpandedChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.ScrollBar OnIsExpandedChanged(this Avalonia.Controls.Primitives.ScrollBar obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.IsExpandedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -514,6 +704,54 @@ public static partial class ScrollBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAllowAutoHide(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAllowAutoHide<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAllowAutoHideChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAllowAutoHideChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.AllowAutoHideProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty
 
     /// <summary>
@@ -612,6 +850,54 @@ public static partial class ScrollBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingHideDelay(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHideDelay<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHideDelayChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHideDelayChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.HideDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty
 
     /// <summary>
@@ -706,6 +992,54 @@ public static partial class ScrollBarExtensions
     public static T OnShowDelay<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<System.TimeSpan>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingShowDelay(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowDelay<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowDelayChanged(this Avalonia.Controls.Primitives.ScrollBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowDelayChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ScrollBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ScrollBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ScrollBar.ShowDelayProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ScrollContentPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ScrollContentPresenter.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ScrollContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanHorizontallyScroll(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanHorizontallyScroll<T>(this T obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Presenters.ScrollContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanHorizontallyScrollChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanHorizontallyScrollChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ScrollContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanHorizontallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ScrollContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanVerticallyScroll(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanVerticallyScroll<T>(this T obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Presenters.ScrollContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanVerticallyScrollChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanVerticallyScrollChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ScrollContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.CanVerticallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty
 
     /// <summary>
@@ -242,6 +338,52 @@ public static partial class ScrollContentPresenterExtensions
     public static Avalonia.Controls.Presenters.ScrollContentPresenter OnExtent(this Avalonia.Controls.Presenters.ScrollContentPresenter obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<Avalonia.Size>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingExtent(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Presenters.ScrollContentPresenter OnBindingExtent(this Avalonia.Controls.Presenters.ScrollContentPresenter obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveExtentChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Presenters.ScrollContentPresenter OnExtentChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ExtentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -344,6 +486,54 @@ public static partial class ScrollContentPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Vector>> ObserveBindingOffset(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOffset<T>(this T obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<BindingValue<Avalonia.Vector>>> handler) where T : Avalonia.Controls.Presenters.ScrollContentPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffsetChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.ScrollContentPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty
 
     /// <summary>
@@ -384,6 +574,52 @@ public static partial class ScrollContentPresenterExtensions
     public static Avalonia.Controls.Presenters.ScrollContentPresenter OnViewport(this Avalonia.Controls.Presenters.ScrollContentPresenter obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<Avalonia.Size>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingViewport(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Presenters.ScrollContentPresenter OnBindingViewport(this Avalonia.Controls.Presenters.ScrollContentPresenter obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveViewportChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Presenters.ScrollContentPresenter OnViewportChanged(this Avalonia.Controls.Presenters.ScrollContentPresenter obj, Action<Avalonia.Controls.Presenters.ScrollContentPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.ScrollContentPresenter.ViewportProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ScrollGestureRecognizer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ScrollGestureRecognizer.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ScrollGestureRecognizerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanHorizontallyScroll(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanHorizontallyScroll<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanHorizontallyScrollChanged(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanHorizontallyScrollChanged<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanHorizontallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ScrollGestureRecognizerExtensions
     public static T OnCanVerticallyScroll<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<System.Boolean>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
     {
         var observable = obj.GetObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanVerticallyScroll(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanVerticallyScroll<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanVerticallyScrollChanged(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanVerticallyScrollChanged<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.CanVerticallyScrollProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class ScrollGestureRecognizerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsScrollInertiaEnabled(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsScrollInertiaEnabled<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsScrollInertiaEnabledChanged(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsScrollInertiaEnabledChanged<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.IsScrollInertiaEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class ScrollGestureRecognizerExtensions
     public static T OnScrollStartDistance<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<System.Int32>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
     {
         var observable = obj.GetObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingScrollStartDistance(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingScrollStartDistance<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveScrollStartDistanceChanged(this Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnScrollStartDistanceChanged<T>(this T obj, Action<Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Input.GestureRecognizers.ScrollGestureRecognizer.ScrollStartDistanceProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ScrollViewer.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ScrollViewer.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ScrollViewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingBringIntoViewOnFocusChange(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBringIntoViewOnFocusChange<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBringIntoViewOnFocusChangeChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBringIntoViewOnFocusChangeChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.BringIntoViewOnFocusChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ScrollViewer.ExtentProperty
 
     /// <summary>
@@ -144,6 +192,52 @@ public static partial class ScrollViewerExtensions
     public static Avalonia.Controls.ScrollViewer OnExtent(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<Avalonia.Size>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.ExtentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingExtent(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.ExtentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnBindingExtent(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.ExtentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveExtentChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.ExtentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.ExtentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnExtentChanged(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.ExtentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -246,6 +340,54 @@ public static partial class ScrollViewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Vector>> ObserveBindingOffset(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOffset<T>(this T obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<Avalonia.Vector>>> handler) where T : Avalonia.Controls.ScrollViewer
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffsetChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.OffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.OffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOffsetChanged<T>(this T obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ScrollViewer
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.OffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ScrollViewer.ViewportProperty
 
     /// <summary>
@@ -286,6 +428,52 @@ public static partial class ScrollViewerExtensions
     public static Avalonia.Controls.ScrollViewer OnViewport(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<Avalonia.Size>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.ViewportProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingViewport(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.ViewportProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnBindingViewport(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.ViewportProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveViewportChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.ViewportProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.ViewportProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnViewportChanged(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.ViewportProperty);
         handler(obj, observable);
         return obj;
     }
@@ -334,6 +522,52 @@ public static partial class ScrollViewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingLargeChange(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.LargeChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnBindingLargeChange(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.LargeChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLargeChangeChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.LargeChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.LargeChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnLargeChangeChanged(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.LargeChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ScrollViewer.SmallChangeProperty
 
     /// <summary>
@@ -378,6 +612,52 @@ public static partial class ScrollViewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingSmallChange(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.SmallChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnBindingSmallChange(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.SmallChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSmallChangeChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.SmallChangeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.SmallChangeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnSmallChangeChanged(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.SmallChangeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty
 
     /// <summary>
@@ -418,6 +698,52 @@ public static partial class ScrollViewerExtensions
     public static Avalonia.Controls.ScrollViewer OnScrollBarMaximum(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<Avalonia.Vector>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Vector>> ObserveBindingScrollBarMaximum(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnBindingScrollBarMaximum(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<Avalonia.Vector>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveScrollBarMaximumChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnScrollBarMaximumChanged(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.ScrollBarMaximumProperty);
         handler(obj, observable);
         return obj;
     }
@@ -516,6 +842,54 @@ public static partial class ScrollViewerExtensions
     public static T OnHorizontalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Controls.Primitives.ScrollBarVisibility>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>> ObserveBindingHorizontalScrollBarVisibility(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalScrollBarVisibilityChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalScrollBarVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.HorizontalScrollBarVisibilityProperty);
         handler(obj, observable);
         return obj;
     }
@@ -667,6 +1041,54 @@ public static partial class ScrollViewerExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsType>> ObserveBindingHorizontalSnapPointsType(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalSnapPointsType<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsType>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalSnapPointsTypeChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalSnapPointsTypeChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsTypeProperty"/> property value to <see cref="Avalonia.Controls.Primitives.SnapPointsType.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -796,6 +1218,54 @@ public static partial class ScrollViewerExtensions
     public static T OnVerticalSnapPointsType<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Controls.Primitives.SnapPointsType>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsType>> ObserveBindingVerticalSnapPointsType(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalSnapPointsType<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsType>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalSnapPointsTypeChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalSnapPointsTypeChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsTypeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -935,6 +1405,54 @@ public static partial class ScrollViewerExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsAlignment>> ObserveBindingHorizontalSnapPointsAlignment(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalSnapPointsAlignment<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsAlignment>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalSnapPointsAlignmentChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalSnapPointsAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ScrollViewer.HorizontalSnapPointsAlignmentProperty"/> property value to <see cref="Avalonia.Controls.Primitives.SnapPointsAlignment.Near"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1064,6 +1582,54 @@ public static partial class ScrollViewerExtensions
     public static T OnVerticalSnapPointsAlignment<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Controls.Primitives.SnapPointsAlignment>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsAlignment>> ObserveBindingVerticalSnapPointsAlignment(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalSnapPointsAlignment<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.SnapPointsAlignment>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalSnapPointsAlignmentChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalSnapPointsAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.VerticalSnapPointsAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1203,6 +1769,54 @@ public static partial class ScrollViewerExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>> ObserveBindingVerticalScrollBarVisibility(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalScrollBarVisibility<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.ScrollBarVisibility>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalScrollBarVisibilityChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalScrollBarVisibilityChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.ScrollViewer.VerticalScrollBarVisibilityProperty"/> property value to <see cref="Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1290,6 +1904,52 @@ public static partial class ScrollViewerExtensions
     public static Avalonia.Controls.ScrollViewer OnIsExpanded(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsExpanded(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnBindingIsExpanded(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsExpandedChanged(this Avalonia.Controls.ScrollViewer obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.ScrollViewer OnIsExpandedChanged(this Avalonia.Controls.ScrollViewer obj, Action<Avalonia.Controls.ScrollViewer, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsExpandedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1392,6 +2052,54 @@ public static partial class ScrollViewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAllowAutoHide(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.AllowAutoHideProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAllowAutoHide<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.AllowAutoHideProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAllowAutoHideChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.AllowAutoHideProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.AllowAutoHideProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAllowAutoHideChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.AllowAutoHideProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty
 
     /// <summary>
@@ -1486,6 +2194,54 @@ public static partial class ScrollViewerExtensions
     public static T OnIsScrollChainingEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsScrollChainingEnabled(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsScrollChainingEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsScrollChainingEnabledChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsScrollChainingEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsScrollChainingEnabledProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1588,6 +2344,54 @@ public static partial class ScrollViewerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsScrollInertiaEnabled(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsScrollInertiaEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsScrollInertiaEnabledChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsScrollInertiaEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsScrollInertiaEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty
 
     /// <summary>
@@ -1682,6 +2486,54 @@ public static partial class ScrollViewerExtensions
     public static T OnIsDeferredScrollingEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDeferredScrollingEnabled(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDeferredScrollingEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDeferredScrollingEnabledChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDeferredScrollingEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ScrollViewer.IsDeferredScrollingEnabledProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Sector.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Sector.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class SectorExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Sector.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStartAngle(this Avalonia.Controls.Shapes.Sector obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Sector.StartAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Sector.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStartAngle<T>(this T obj, Action<Avalonia.Controls.Shapes.Sector, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Sector
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Sector.StartAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Sector.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStartAngleChanged(this Avalonia.Controls.Shapes.Sector obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Sector.StartAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Sector.StartAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStartAngleChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Sector, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Sector
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Sector.StartAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Sector.SweepAngleProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class SectorExtensions
     public static T OnSweepAngle<T>(this T obj, Action<Avalonia.Controls.Shapes.Sector, IObservable<System.Double>> handler) where T : Avalonia.Controls.Shapes.Sector
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Sector.SweepAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Sector.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSweepAngle(this Avalonia.Controls.Shapes.Sector obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Sector.SweepAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Sector.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSweepAngle<T>(this T obj, Action<Avalonia.Controls.Shapes.Sector, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Sector
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Sector.SweepAngleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Sector.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSweepAngleChanged(this Avalonia.Controls.Shapes.Sector obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Sector.SweepAngleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Sector.SweepAngleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSweepAngleChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Sector, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Sector
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Sector.SweepAngleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/SelectableTextBlock.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SelectableTextBlock.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class SelectableTextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectionStart(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionStart<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionStartChanged(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionStartChanged<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SelectableTextBlock.SelectionEndProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class SelectableTextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectionEnd(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionEnd<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionEndChanged(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionEndChanged<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SelectableTextBlock.SelectedTextProperty
 
     /// <summary>
@@ -242,6 +338,52 @@ public static partial class SelectableTextBlockExtensions
     public static Avalonia.Controls.SelectableTextBlock OnSelectedText(this Avalonia.Controls.SelectableTextBlock obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<System.String>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.SelectableTextBlock.SelectedTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectedTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingSelectedText(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectedTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectedTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.SelectableTextBlock OnBindingSelectedText(this Avalonia.Controls.SelectableTextBlock obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<BindingValue<System.String>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectedTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectedTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedTextChanged(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectedTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectedTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.SelectableTextBlock OnSelectedTextChanged(this Avalonia.Controls.SelectableTextBlock obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectedTextProperty);
         handler(obj, observable);
         return obj;
     }
@@ -344,6 +486,54 @@ public static partial class SelectableTextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSelectionBrush(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionBrush<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionBrushChanged(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionBrushChanged<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty
 
     /// <summary>
@@ -442,6 +632,54 @@ public static partial class SelectableTextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSelectionForegroundBrush(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionForegroundBrush<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionForegroundBrushChanged(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionForegroundBrushChanged<T>(this T obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SelectableTextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.SelectionForegroundBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SelectableTextBlock.CanCopyProperty
 
     /// <summary>
@@ -482,6 +720,52 @@ public static partial class SelectableTextBlockExtensions
     public static Avalonia.Controls.SelectableTextBlock OnCanCopy(this Avalonia.Controls.SelectableTextBlock obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.SelectableTextBlock.CanCopyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanCopy(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.CanCopyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SelectableTextBlock.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.SelectableTextBlock OnBindingCanCopy(this Avalonia.Controls.SelectableTextBlock obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SelectableTextBlock.CanCopyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanCopyChanged(this Avalonia.Controls.SelectableTextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.CanCopyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SelectableTextBlock.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.SelectableTextBlock OnCanCopyChanged(this Avalonia.Controls.SelectableTextBlock obj, Action<Avalonia.Controls.SelectableTextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SelectableTextBlock.CanCopyProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/SelectingItemsControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SelectingItemsControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class SelectingItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAutoScrollToSelectedItem(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAutoScrollToSelectedItem<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAutoScrollToSelectedItemChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAutoScrollToSelectedItemChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.AutoScrollToSelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class SelectingItemsControlExtensions
     public static T OnSelectedIndex<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectedIndex(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedIndex<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedIndexChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedIndexChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedIndexProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class SelectingItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectedItem(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedItem<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedItemChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedItemChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class SelectingItemsControlExtensions
     public static T OnSelectedValue<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<System.Object>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectedValue(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedValue<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedValueChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class SelectingItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Data.IBinding>> ObserveBindingSelectedValueBinding(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedValueBinding<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<Avalonia.Data.IBinding>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedValueBindingChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedValueBindingChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.SelectedValueBindingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class SelectingItemsControlExtensions
     public static T OnIsSelected<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSelected(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsSelected<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSelectedChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsSelectedChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsSelectedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class SelectingItemsControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsTextSearchEnabled(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsTextSearchEnabled<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsTextSearchEnabledChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsTextSearchEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.IsTextSearchEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class SelectingItemsControlExtensions
     public static T OnWrapSelection<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingWrapSelection(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWrapSelection<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWrapSelectionChanged(this Avalonia.Controls.Primitives.SelectingItemsControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWrapSelectionChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SelectingItemsControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SelectingItemsControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SelectingItemsControl.WrapSelectionProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Shape.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Shape.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ShapeExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingFill(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.FillProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFill<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.FillProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFillChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.FillProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFillChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.FillProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Shape.StretchProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ShapeExtensions
     public static T OnStretch<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<Avalonia.Media.Stretch>> handler) where T : Avalonia.Controls.Shapes.Shape
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Shape.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Stretch>> ObserveBindingStretch(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStretch<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<Avalonia.Media.Stretch>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStretchChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStretchChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StretchProperty);
         handler(obj, observable);
         return obj;
     }
@@ -348,6 +444,54 @@ public static partial class ShapeExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingStroke(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStroke<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty
 
     /// <summary>
@@ -442,6 +586,54 @@ public static partial class ShapeExtensions
     public static T OnStrokeDashArray<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<Avalonia.Collections.AvaloniaList<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Shape
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>> ObserveBindingStrokeDashArray(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeDashArray<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeDashArrayChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeDashArrayChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeDashArrayProperty);
         handler(obj, observable);
         return obj;
     }
@@ -544,6 +736,54 @@ public static partial class ShapeExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStrokeDashOffset(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeDashOffset<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeDashOffsetChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeDashOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeDashOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty
 
     /// <summary>
@@ -642,6 +882,54 @@ public static partial class ShapeExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStrokeThickness(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeThickness<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeThicknessChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeThicknessChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty
 
     /// <summary>
@@ -736,6 +1024,54 @@ public static partial class ShapeExtensions
     public static T OnStrokeLineCap<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<Avalonia.Media.PenLineCap>> handler) where T : Avalonia.Controls.Shapes.Shape
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PenLineCap>> ObserveBindingStrokeLineCap(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeLineCap<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<Avalonia.Media.PenLineCap>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeLineCapChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeLineCapChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeLineCapProperty);
         handler(obj, observable);
         return obj;
     }
@@ -870,6 +1206,54 @@ public static partial class ShapeExtensions
     public static T OnStrokeJoin<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<Avalonia.Media.PenLineJoin>> handler) where T : Avalonia.Controls.Shapes.Shape
     {
         var observable = obj.GetObservable(Avalonia.Controls.Shapes.Shape.StrokeJoinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PenLineJoin>> ObserveBindingStrokeJoin(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeJoinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeJoin<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<BindingValue<Avalonia.Media.PenLineJoin>>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Shapes.Shape.StrokeJoinProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeJoinChanged(this Avalonia.Controls.Shapes.Shape obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeJoinProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Shapes.Shape.StrokeJoinProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeJoinChanged<T>(this T obj, Action<Avalonia.Controls.Shapes.Shape, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Shapes.Shape
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Shapes.Shape.StrokeJoinProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/SkewTransform.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SkewTransform.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class SkewTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.SkewTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngleX(this Avalonia.Media.SkewTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.SkewTransform.AngleXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.SkewTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.SkewTransform OnBindingAngleX(this Avalonia.Media.SkewTransform obj, Action<Avalonia.Media.SkewTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.SkewTransform.AngleXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.SkewTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleXChanged(this Avalonia.Media.SkewTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.SkewTransform.AngleXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.SkewTransform.AngleXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.SkewTransform OnAngleXChanged(this Avalonia.Media.SkewTransform obj, Action<Avalonia.Media.SkewTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.SkewTransform.AngleXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.SkewTransform.AngleYProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class SkewTransformExtensions
     public static Avalonia.Media.SkewTransform OnAngleY(this Avalonia.Media.SkewTransform obj, Action<Avalonia.Media.SkewTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.SkewTransform.AngleYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.SkewTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingAngleY(this Avalonia.Media.SkewTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.SkewTransform.AngleYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.SkewTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.SkewTransform OnBindingAngleY(this Avalonia.Media.SkewTransform obj, Action<Avalonia.Media.SkewTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.SkewTransform.AngleYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.SkewTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAngleYChanged(this Avalonia.Media.SkewTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.SkewTransform.AngleYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.SkewTransform.AngleYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.SkewTransform OnAngleYChanged(this Avalonia.Media.SkewTransform obj, Action<Avalonia.Media.SkewTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.SkewTransform.AngleYProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Slider.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Slider.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class SliderExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Slider.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Slider.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Slider.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Slider.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Slider.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Slider.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Slider.OrientationProperty"/> property value to <see cref="Avalonia.Layout.Orientation.Horizontal"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -226,6 +274,54 @@ public static partial class SliderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Slider.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDirectionReversed(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Slider.IsDirectionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Slider.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDirectionReversed<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Slider.IsDirectionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Slider.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDirectionReversedChanged(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.IsDirectionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Slider.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDirectionReversedChanged<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.IsDirectionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Slider.IsSnapToTickEnabledProperty
 
     /// <summary>
@@ -320,6 +416,54 @@ public static partial class SliderExtensions
     public static T OnIsSnapToTickEnabled<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Slider
     {
         var observable = obj.GetObservable(Avalonia.Controls.Slider.IsSnapToTickEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Slider.IsSnapToTickEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSnapToTickEnabled(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Slider.IsSnapToTickEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Slider.IsSnapToTickEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsSnapToTickEnabled<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Slider.IsSnapToTickEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Slider.IsSnapToTickEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSnapToTickEnabledChanged(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.IsSnapToTickEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Slider.IsSnapToTickEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsSnapToTickEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.IsSnapToTickEnabledProperty);
         handler(obj, observable);
         return obj;
     }
@@ -422,6 +566,54 @@ public static partial class SliderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Slider.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingTickFrequency(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Slider.TickFrequencyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Slider.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTickFrequency<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Slider.TickFrequencyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Slider.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTickFrequencyChanged(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.TickFrequencyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Slider.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTickFrequencyChanged<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.TickFrequencyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Slider.TickPlacementProperty
 
     /// <summary>
@@ -516,6 +708,54 @@ public static partial class SliderExtensions
     public static T OnTickPlacement<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<Avalonia.Controls.TickPlacement>> handler) where T : Avalonia.Controls.Slider
     {
         var observable = obj.GetObservable(Avalonia.Controls.Slider.TickPlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Slider.TickPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.TickPlacement>> ObserveBindingTickPlacement(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Slider.TickPlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Slider.TickPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTickPlacement<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<BindingValue<Avalonia.Controls.TickPlacement>>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Slider.TickPlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Slider.TickPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTickPlacementChanged(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.TickPlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Slider.TickPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTickPlacementChanged<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.TickPlacementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -662,6 +902,54 @@ public static partial class SliderExtensions
     public static T OnTicks<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<Avalonia.Collections.AvaloniaList<System.Double>>> handler) where T : Avalonia.Controls.Slider
     {
         var observable = obj.GetObservable(Avalonia.Controls.Slider.TicksProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Slider.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>> ObserveBindingTicks(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Slider.TicksProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Slider.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTicks<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Slider.TicksProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Slider.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTicksChanged(this Avalonia.Controls.Slider obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.TicksProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Slider.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTicksChanged<T>(this T obj, Action<Avalonia.Controls.Slider, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Slider
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Slider.TicksProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/SolidColorBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SolidColorBrush.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class SolidColorBrushExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.SolidColorBrush.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Color>> ObserveBindingColor(this Avalonia.Media.SolidColorBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.SolidColorBrush.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.SolidColorBrush.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.SolidColorBrush OnBindingColor(this Avalonia.Media.SolidColorBrush obj, Action<Avalonia.Media.SolidColorBrush, IObservable<BindingValue<Avalonia.Media.Color>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.SolidColorBrush.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.SolidColorBrush.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColorChanged(this Avalonia.Media.SolidColorBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.SolidColorBrush.ColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.SolidColorBrush.ColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.SolidColorBrush OnColorChanged(this Avalonia.Media.SolidColorBrush obj, Action<Avalonia.Media.SolidColorBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.SolidColorBrush.ColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Span.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Span.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class SpanExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.Span.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Documents.InlineCollection>> ObserveBindingInlines(this Avalonia.Controls.Documents.Span obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.Span.InlinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.Span.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInlines<T>(this T obj, Action<Avalonia.Controls.Documents.Span, IObservable<BindingValue<Avalonia.Controls.Documents.InlineCollection>>> handler) where T : Avalonia.Controls.Documents.Span
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.Span.InlinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.Span.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInlinesChanged(this Avalonia.Controls.Documents.Span obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Span.InlinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.Span.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInlinesChanged<T>(this T obj, Action<Avalonia.Controls.Documents.Span, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.Span
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.Span.InlinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Spinner.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Spinner.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class SpinnerExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Spinner.ValidSpinDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ValidSpinDirections>> ObserveBindingValidSpinDirection(this Avalonia.Controls.Spinner obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Spinner.ValidSpinDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Spinner.ValidSpinDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingValidSpinDirection<T>(this T obj, Action<Avalonia.Controls.Spinner, IObservable<BindingValue<Avalonia.Controls.ValidSpinDirections>>> handler) where T : Avalonia.Controls.Spinner
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Spinner.ValidSpinDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Spinner.ValidSpinDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveValidSpinDirectionChanged(this Avalonia.Controls.Spinner obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Spinner.ValidSpinDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Spinner.ValidSpinDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnValidSpinDirectionChanged<T>(this T obj, Action<Avalonia.Controls.Spinner, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Spinner
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Spinner.ValidSpinDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Spinner.ValidSpinDirectionProperty"/> property value to <see cref="Avalonia.Controls.ValidSpinDirections.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>

--- a/src/NXUI/Generated/Extensions/SplitButton.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SplitButton.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class SplitButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitButton.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Windows.Input.ICommand>> ObserveBindingCommand(this Avalonia.Controls.SplitButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitButton.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitButton.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommand<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<BindingValue<System.Windows.Input.ICommand>>> handler) where T : Avalonia.Controls.SplitButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitButton.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitButton.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandChanged(this Avalonia.Controls.SplitButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitButton.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitButton.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandChanged<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitButton.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitButton.CommandParameterProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class SplitButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitButton.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingCommandParameter(this Avalonia.Controls.SplitButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitButton.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitButton.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommandParameter<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.SplitButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitButton.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitButton.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandParameterChanged(this Avalonia.Controls.SplitButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitButton.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitButton.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandParameterChanged<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitButton.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitButton.FlyoutProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class SplitButtonExtensions
     public static T OnFlyout<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<Avalonia.Controls.Primitives.FlyoutBase>> handler) where T : Avalonia.Controls.SplitButton
     {
         var observable = obj.GetObservable(Avalonia.Controls.SplitButton.FlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitButton.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>> ObserveBindingFlyout(this Avalonia.Controls.SplitButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitButton.FlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitButton.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFlyout<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<BindingValue<Avalonia.Controls.Primitives.FlyoutBase>>> handler) where T : Avalonia.Controls.SplitButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitButton.FlyoutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitButton.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFlyoutChanged(this Avalonia.Controls.SplitButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitButton.FlyoutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitButton.FlyoutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFlyoutChanged<T>(this T obj, Action<Avalonia.Controls.SplitButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitButton.FlyoutProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/SplitView.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SplitView.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class SplitViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.CompactPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingCompactPaneLength(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.CompactPaneLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.CompactPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCompactPaneLength<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.CompactPaneLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.CompactPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCompactPaneLengthChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.CompactPaneLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.CompactPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCompactPaneLengthChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.CompactPaneLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitView.DisplayModeProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class SplitViewExtensions
     public static T OnDisplayMode<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<Avalonia.Controls.SplitViewDisplayMode>> handler) where T : Avalonia.Controls.SplitView
     {
         var observable = obj.GetObservable(Avalonia.Controls.SplitView.DisplayModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.SplitViewDisplayMode>> ObserveBindingDisplayMode(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.DisplayModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisplayMode<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<Avalonia.Controls.SplitViewDisplayMode>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.DisplayModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisplayModeChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.DisplayModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.DisplayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisplayModeChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.DisplayModeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -348,6 +444,54 @@ public static partial class SplitViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.IsPaneOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsPaneOpen(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.IsPaneOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.IsPaneOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsPaneOpen<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.IsPaneOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.IsPaneOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsPaneOpenChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.IsPaneOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.IsPaneOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsPaneOpenChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.IsPaneOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitView.OpenPaneLengthProperty
 
     /// <summary>
@@ -442,6 +586,54 @@ public static partial class SplitViewExtensions
     public static T OnOpenPaneLength<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<System.Double>> handler) where T : Avalonia.Controls.SplitView
     {
         var observable = obj.GetObservable(Avalonia.Controls.SplitView.OpenPaneLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.OpenPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOpenPaneLength(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.OpenPaneLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.OpenPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOpenPaneLength<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.OpenPaneLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.OpenPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpenPaneLengthChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.OpenPaneLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.OpenPaneLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOpenPaneLengthChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.OpenPaneLengthProperty);
         handler(obj, observable);
         return obj;
     }
@@ -544,6 +736,54 @@ public static partial class SplitViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.PaneBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingPaneBackground(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.PaneBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.PaneBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPaneBackground<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.PaneBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.PaneBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaneBackgroundChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PaneBackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.PaneBackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaneBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PaneBackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitView.PanePlacementProperty
 
     /// <summary>
@@ -638,6 +878,54 @@ public static partial class SplitViewExtensions
     public static T OnPanePlacement<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<Avalonia.Controls.SplitViewPanePlacement>> handler) where T : Avalonia.Controls.SplitView
     {
         var observable = obj.GetObservable(Avalonia.Controls.SplitView.PanePlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.PanePlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.SplitViewPanePlacement>> ObserveBindingPanePlacement(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.PanePlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.PanePlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPanePlacement<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<Avalonia.Controls.SplitViewPanePlacement>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.PanePlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.PanePlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePanePlacementChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PanePlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.PanePlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPanePlacementChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PanePlacementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -764,6 +1052,54 @@ public static partial class SplitViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.PaneProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingPane(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.PaneProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.PaneProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPane<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.PaneProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.PaneProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaneChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PaneProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.PaneProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaneChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PaneProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitView.PaneTemplateProperty
 
     /// <summary>
@@ -858,6 +1194,54 @@ public static partial class SplitViewExtensions
     public static T OnPaneTemplate<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.SplitView
     {
         var observable = obj.GetObservable(Avalonia.Controls.SplitView.PaneTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.PaneTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingPaneTemplate(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.PaneTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.PaneTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPaneTemplate<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.PaneTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.PaneTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaneTemplateChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PaneTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.PaneTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaneTemplateChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.PaneTemplateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -960,6 +1344,54 @@ public static partial class SplitViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseLightDismissOverlayMode(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseLightDismissOverlayMode<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseLightDismissOverlayModeChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseLightDismissOverlayModeChanged<T>(this T obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.SplitView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.UseLightDismissOverlayModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.SplitView.TemplateSettingsProperty
 
     /// <summary>
@@ -1000,6 +1432,52 @@ public static partial class SplitViewExtensions
     public static Avalonia.Controls.SplitView OnTemplateSettings(this Avalonia.Controls.SplitView obj, Action<Avalonia.Controls.SplitView, IObservable<Avalonia.Controls.Primitives.SplitViewTemplateSettings>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.SplitView.TemplateSettingsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.SplitView.TemplateSettingsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.SplitViewTemplateSettings>> ObserveBindingTemplateSettings(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.SplitView.TemplateSettingsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.SplitView.TemplateSettingsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.SplitView OnBindingTemplateSettings(this Avalonia.Controls.SplitView obj, Action<Avalonia.Controls.SplitView, IObservable<BindingValue<Avalonia.Controls.Primitives.SplitViewTemplateSettings>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.SplitView.TemplateSettingsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.SplitView.TemplateSettingsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTemplateSettingsChanged(this Avalonia.Controls.SplitView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.TemplateSettingsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.SplitView.TemplateSettingsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.SplitView OnTemplateSettingsChanged(this Avalonia.Controls.SplitView obj, Action<Avalonia.Controls.SplitView, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.SplitView.TemplateSettingsProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/SplitViewTemplateSettings.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/SplitViewTemplateSettings.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class SplitViewTemplateSettingsExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingClosedPaneWidth(this Avalonia.Controls.Primitives.SplitViewTemplateSettings obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClosedPaneWidth<T>(this T obj, Action<Avalonia.Controls.Primitives.SplitViewTemplateSettings, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.SplitViewTemplateSettings
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClosedPaneWidthChanged(this Avalonia.Controls.Primitives.SplitViewTemplateSettings obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClosedPaneWidthChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SplitViewTemplateSettings, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SplitViewTemplateSettings
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.ClosedPaneWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class SplitViewTemplateSettingsExtensions
     public static T OnPaneColumnGridLength<T>(this T obj, Action<Avalonia.Controls.Primitives.SplitViewTemplateSettings, IObservable<Avalonia.Controls.GridLength>> handler) where T : Avalonia.Controls.Primitives.SplitViewTemplateSettings
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.GridLength>> ObserveBindingPaneColumnGridLength(this Avalonia.Controls.Primitives.SplitViewTemplateSettings obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPaneColumnGridLength<T>(this T obj, Action<Avalonia.Controls.Primitives.SplitViewTemplateSettings, IObservable<BindingValue<Avalonia.Controls.GridLength>>> handler) where T : Avalonia.Controls.Primitives.SplitViewTemplateSettings
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaneColumnGridLengthChanged(this Avalonia.Controls.Primitives.SplitViewTemplateSettings obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaneColumnGridLengthChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.SplitViewTemplateSettings, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.SplitViewTemplateSettings
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.SplitViewTemplateSettings.PaneColumnGridLengthProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/StackLayout.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/StackLayout.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class StackLayoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.StackLayout.DisableVirtualizationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingDisableVirtualization(this Avalonia.Layout.StackLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.StackLayout.DisableVirtualizationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.StackLayout.DisableVirtualizationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDisableVirtualization<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Layout.StackLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.StackLayout.DisableVirtualizationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.StackLayout.DisableVirtualizationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDisableVirtualizationChanged(this Avalonia.Layout.StackLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.StackLayout.DisableVirtualizationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.StackLayout.DisableVirtualizationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDisableVirtualizationChanged<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.StackLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.StackLayout.DisableVirtualizationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.StackLayout.OrientationProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class StackLayoutExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Layout.StackLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.StackLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.StackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Layout.StackLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.StackLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.StackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Layout.StackLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.StackLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.StackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Layout.StackLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.StackLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.StackLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.StackLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.StackLayout.OrientationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -320,6 +416,54 @@ public static partial class StackLayoutExtensions
     public static T OnSpacing<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<System.Double>> handler) where T : Avalonia.Layout.StackLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.StackLayout.SpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.StackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSpacing(this Avalonia.Layout.StackLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.StackLayout.SpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.StackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSpacing<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.StackLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.StackLayout.SpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.StackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSpacingChanged(this Avalonia.Layout.StackLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.StackLayout.SpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.StackLayout.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSpacingChanged<T>(this T obj, Action<Avalonia.Layout.StackLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.StackLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.StackLayout.SpacingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/StackPanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/StackPanel.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class StackPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.StackPanel.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingSpacing(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.StackPanel.SpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.StackPanel.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSpacing<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.StackPanel.SpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.StackPanel.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSpacingChanged(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.SpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.StackPanel.SpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSpacingChanged<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.SpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.StackPanel.OrientationProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class StackPanelExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Controls.StackPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.StackPanel.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.StackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.StackPanel.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.StackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.StackPanel.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.StackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.StackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.OrientationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -324,6 +420,54 @@ public static partial class StackPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreHorizontalSnapPointsRegular(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreHorizontalSnapPointsRegular<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreHorizontalSnapPointsRegularChanged(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreHorizontalSnapPointsRegularChanged<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.AreHorizontalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty
 
     /// <summary>
@@ -418,6 +562,54 @@ public static partial class StackPanelExtensions
     public static T OnAreVerticalSnapPointsRegular<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.StackPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreVerticalSnapPointsRegular(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreVerticalSnapPointsRegular<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreVerticalSnapPointsRegularChanged(this Avalonia.Controls.StackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreVerticalSnapPointsRegularChanged<T>(this T obj, Action<Avalonia.Controls.StackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.StackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.StackPanel.AreVerticalSnapPointsRegularProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/StyledElement.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/StyledElement.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class StyledElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.StyledElement.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingDataContext(this Avalonia.StyledElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.StyledElement.DataContextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.StyledElement.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDataContext<T>(this T obj, Action<Avalonia.StyledElement, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.StyledElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.StyledElement.DataContextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.StyledElement.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDataContextChanged(this Avalonia.StyledElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.StyledElement.DataContextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.StyledElement.DataContextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDataContextChanged<T>(this T obj, Action<Avalonia.StyledElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.StyledElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.StyledElement.DataContextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.StyledElement.NameProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class StyledElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.StyledElement.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingName(this Avalonia.StyledElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.StyledElement.NameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.StyledElement.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingName<T>(this T obj, Action<Avalonia.StyledElement, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.StyledElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.StyledElement.NameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.StyledElement.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveNameChanged(this Avalonia.StyledElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.StyledElement.NameProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.StyledElement.NameProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnNameChanged<T>(this T obj, Action<Avalonia.StyledElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.StyledElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.StyledElement.NameProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.StyledElement.ParentProperty
 
     /// <summary>
@@ -246,6 +342,52 @@ public static partial class StyledElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.StyledElement.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.StyledElement>> ObserveBindingParent(this Avalonia.StyledElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.StyledElement.ParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.StyledElement.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.StyledElement OnBindingParent(this Avalonia.StyledElement obj, Action<Avalonia.StyledElement, IObservable<BindingValue<Avalonia.StyledElement>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.StyledElement.ParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.StyledElement.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveParentChanged(this Avalonia.StyledElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.StyledElement.ParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.StyledElement.ParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.StyledElement OnParentChanged(this Avalonia.StyledElement obj, Action<Avalonia.StyledElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.StyledElement.ParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.StyledElement.TemplatedParentProperty
 
     /// <summary>
@@ -286,6 +428,52 @@ public static partial class StyledElementExtensions
     public static Avalonia.StyledElement OnTemplatedParent(this Avalonia.StyledElement obj, Action<Avalonia.StyledElement, IObservable<Avalonia.AvaloniaObject>> handler)
     {
         var observable = obj.GetObservable(Avalonia.StyledElement.TemplatedParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.StyledElement.TemplatedParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.AvaloniaObject>> ObserveBindingTemplatedParent(this Avalonia.StyledElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.StyledElement.TemplatedParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.StyledElement.TemplatedParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.StyledElement OnBindingTemplatedParent(this Avalonia.StyledElement obj, Action<Avalonia.StyledElement, IObservable<BindingValue<Avalonia.AvaloniaObject>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.StyledElement.TemplatedParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.StyledElement.TemplatedParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTemplatedParentChanged(this Avalonia.StyledElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.StyledElement.TemplatedParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.StyledElement.TemplatedParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.StyledElement OnTemplatedParentChanged(this Avalonia.StyledElement obj, Action<Avalonia.StyledElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.StyledElement.TemplatedParentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -384,6 +572,54 @@ public static partial class StyledElementExtensions
     public static T OnTheme<T>(this T obj, Action<Avalonia.StyledElement, IObservable<Avalonia.Styling.ControlTheme>> handler) where T : Avalonia.StyledElement
     {
         var observable = obj.GetObservable(Avalonia.StyledElement.ThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.StyledElement.ThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Styling.ControlTheme>> ObserveBindingTheme(this Avalonia.StyledElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.StyledElement.ThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.StyledElement.ThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTheme<T>(this T obj, Action<Avalonia.StyledElement, IObservable<BindingValue<Avalonia.Styling.ControlTheme>>> handler) where T : Avalonia.StyledElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.StyledElement.ThemeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.StyledElement.ThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveThemeChanged(this Avalonia.StyledElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.StyledElement.ThemeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.StyledElement.ThemeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnThemeChanged<T>(this T obj, Action<Avalonia.StyledElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.StyledElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.StyledElement.ThemeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TabControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TabControl.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class TabControlExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabControl.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Dock>> ObserveBindingTabStripPlacement(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabControl.TabStripPlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabControl.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTabStripPlacement<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<BindingValue<Avalonia.Controls.Dock>>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabControl.TabStripPlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabControl.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTabStripPlacementChanged(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.TabStripPlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabControl.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTabStripPlacementChanged<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.TabStripPlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.TabControl.TabStripPlacementProperty"/> property value to <see cref="Avalonia.Controls.Dock.Left"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -246,6 +294,54 @@ public static partial class TabControlExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.TabControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -397,6 +493,54 @@ public static partial class TabControlExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabControl.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabControl.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabControl.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.TabControl.VerticalContentAlignmentProperty"/> property value to <see cref="Avalonia.Layout.VerticalAlignment.Stretch"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -542,6 +686,54 @@ public static partial class TabControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingContentTemplate(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabControl.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingContentTemplate<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabControl.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTemplateChanged(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabControl.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.TabControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TabControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TabControl.SelectedContentProperty
 
     /// <summary>
@@ -586,6 +778,52 @@ public static partial class TabControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabControl.SelectedContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectedContent(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabControl.SelectedContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabControl.SelectedContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TabControl OnBindingSelectedContent(this Avalonia.Controls.TabControl obj, Action<Avalonia.Controls.TabControl, IObservable<BindingValue<System.Object>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabControl.SelectedContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabControl.SelectedContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedContentChanged(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.SelectedContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabControl.SelectedContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TabControl OnSelectedContentChanged(this Avalonia.Controls.TabControl obj, Action<Avalonia.Controls.TabControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.SelectedContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TabControl.SelectedContentTemplateProperty
 
     /// <summary>
@@ -626,6 +864,52 @@ public static partial class TabControlExtensions
     public static Avalonia.Controls.TabControl OnSelectedContentTemplate(this Avalonia.Controls.TabControl obj, Action<Avalonia.Controls.TabControl, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TabControl.SelectedContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabControl.SelectedContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingSelectedContentTemplate(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabControl.SelectedContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabControl.SelectedContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TabControl OnBindingSelectedContentTemplate(this Avalonia.Controls.TabControl obj, Action<Avalonia.Controls.TabControl, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabControl.SelectedContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabControl.SelectedContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedContentTemplateChanged(this Avalonia.Controls.TabControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.SelectedContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabControl.SelectedContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TabControl OnSelectedContentTemplateChanged(this Avalonia.Controls.TabControl obj, Action<Avalonia.Controls.TabControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabControl.SelectedContentTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TabItem.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TabItem.Extensions.g.cs
@@ -50,4 +50,50 @@ public static partial class TabItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TabItem.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<Avalonia.Controls.Dock>>> ObserveBindingTabStripPlacement(this Avalonia.Controls.TabItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TabItem.TabStripPlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TabItem.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TabItem OnBindingTabStripPlacement(this Avalonia.Controls.TabItem obj, Action<Avalonia.Controls.TabItem, IObservable<BindingValue<System.Nullable<Avalonia.Controls.Dock>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TabItem.TabStripPlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TabItem.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTabStripPlacementChanged(this Avalonia.Controls.TabItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TabItem.TabStripPlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TabItem.TabStripPlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TabItem OnTabStripPlacementChanged(this Avalonia.Controls.TabItem obj, Action<Avalonia.Controls.TabItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TabItem.TabStripPlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
 }

--- a/src/NXUI/Generated/Extensions/TemplatedControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TemplatedControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TemplatedControlExtensions
     public static T OnBackgroundSizing<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<Avalonia.Media.BackgroundSizing>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.BackgroundSizing>> ObserveBindingBackgroundSizing(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackgroundSizing<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.BackgroundSizing>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundSizingChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundSizingChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BackgroundSizingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -336,6 +432,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBorderBrush(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBorderBrush<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBorderBrushChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBorderBrushChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty
 
     /// <summary>
@@ -430,6 +574,54 @@ public static partial class TemplatedControlExtensions
     public static T OnBorderThickness<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<Avalonia.Thickness>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingBorderThickness(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBorderThickness<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBorderThicknessChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBorderThicknessChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.BorderThicknessProperty);
         handler(obj, observable);
         return obj;
     }
@@ -532,6 +724,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.CornerRadius>> ObserveBindingCornerRadius(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCornerRadius<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.CornerRadius>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCornerRadiusChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCornerRadiusChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.CornerRadiusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty
 
     /// <summary>
@@ -626,6 +866,54 @@ public static partial class TemplatedControlExtensions
     public static T OnFontFamily<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<Avalonia.Media.FontFamily>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFamily>> ObserveBindingFontFamily(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFamily<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.FontFamily>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFamilyChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFamilyChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFamilyProperty);
         handler(obj, observable);
         return obj;
     }
@@ -728,6 +1016,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFeatureCollection>> ObserveBindingFontFeatures(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFeatures<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.FontFeatureCollection>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFeaturesChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFeaturesChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontFeaturesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty
 
     /// <summary>
@@ -826,6 +1162,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingFontSize(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontSize<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontSizeChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontSizeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty
 
     /// <summary>
@@ -920,6 +1304,54 @@ public static partial class TemplatedControlExtensions
     public static T OnFontStyle<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<Avalonia.Media.FontStyle>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStyle>> ObserveBindingFontStyle(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStyle<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.FontStyle>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStyleChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStyleChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStyleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1054,6 +1486,54 @@ public static partial class TemplatedControlExtensions
     public static T OnFontWeight<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<Avalonia.Media.FontWeight>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontWeight>> ObserveBindingFontWeight(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontWeight<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.FontWeight>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontWeightChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontWeightChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontWeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1373,6 +1853,54 @@ public static partial class TemplatedControlExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStretch>> ObserveBindingFontStretch(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStretch<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.FontStretch>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStretchChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStretchChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Primitives.TemplatedControl.FontStretchProperty"/> property value to <see cref="Avalonia.Media.FontStretch.UltraCondensed"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1578,6 +2106,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingForeground(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingForeground<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveForegroundChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnForegroundChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty
 
     /// <summary>
@@ -1672,6 +2248,54 @@ public static partial class TemplatedControlExtensions
     public static T OnPadding<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<Avalonia.Thickness>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingPadding(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPadding<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaddingChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaddingChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.PaddingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1774,6 +2398,54 @@ public static partial class TemplatedControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IControlTemplate>> ObserveBindingTemplate(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTemplate<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<BindingValue<Avalonia.Controls.Templates.IControlTemplate>>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTemplateChanged(this Avalonia.Controls.Primitives.TemplatedControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTemplateChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TemplatedControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TemplatedControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.TemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty
 
     /// <summary>
@@ -1868,6 +2540,54 @@ public static partial class TemplatedControlExtensions
     public static T OnIsTemplateFocusTarget<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsTemplateFocusTarget(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsTemplateFocusTarget<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsTemplateFocusTargetChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsTemplateFocusTargetChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TemplatedControl.IsTemplateFocusTargetProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TextBlock.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TextBlock.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.PaddingProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TextBlockExtensions
     public static T OnPadding<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<Avalonia.Thickness>> handler) where T : Avalonia.Controls.TextBlock
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingPadding(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPadding<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Thickness>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.PaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePaddingChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.PaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.PaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPaddingChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.PaddingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFamily>> ObserveBindingFontFamily(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFamily<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.FontFamily>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFamilyChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFamilyChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.FontSizeProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingFontSize(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontSize<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontSizeChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontSizeChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.FontStyleProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class TextBlockExtensions
     public static T OnFontStyle<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<Avalonia.Media.FontStyle>> handler) where T : Avalonia.Controls.TextBlock
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStyle>> ObserveBindingFontStyle(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStyle<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.FontStyle>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStyleChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStyleChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontStyleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -626,6 +866,54 @@ public static partial class TextBlockExtensions
     public static T OnFontWeight<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<Avalonia.Media.FontWeight>> handler) where T : Avalonia.Controls.TextBlock
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontWeight>> ObserveBindingFontWeight(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontWeight<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.FontWeight>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontWeightChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontWeightChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontWeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -945,6 +1233,54 @@ public static partial class TextBlockExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStretch>> ObserveBindingFontStretch(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStretch<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.FontStretch>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStretchChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStretchChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.TextBlock.FontStretchProperty"/> property value to <see cref="Avalonia.Media.FontStretch.UltraCondensed"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1150,6 +1486,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingForeground(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingForeground<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveForegroundChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnForegroundChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.BaselineOffsetProperty
 
     /// <summary>
@@ -1244,6 +1628,54 @@ public static partial class TextBlockExtensions
     public static T OnBaselineOffset<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Double>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.BaselineOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.BaselineOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingBaselineOffset(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.BaselineOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.BaselineOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBaselineOffset<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.BaselineOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.BaselineOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBaselineOffsetChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.BaselineOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.BaselineOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBaselineOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.BaselineOffsetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1346,6 +1778,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.LineHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingLineHeight(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.LineHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.LineHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLineHeight<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.LineHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.LineHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLineHeightChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.LineHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.LineHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLineHeightChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.LineHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.LineSpacingProperty
 
     /// <summary>
@@ -1440,6 +1920,54 @@ public static partial class TextBlockExtensions
     public static T OnLineSpacing<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Double>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.LineSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingLineSpacing(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.LineSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLineSpacing<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.LineSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLineSpacingChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.LineSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLineSpacingChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.LineSpacingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1542,6 +2070,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.LetterSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingLetterSpacing(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.LetterSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.LetterSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLetterSpacing<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.LetterSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.LetterSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLetterSpacingChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.LetterSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.LetterSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLetterSpacingChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.LetterSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.MaxLinesProperty
 
     /// <summary>
@@ -1636,6 +2212,54 @@ public static partial class TextBlockExtensions
     public static T OnMaxLines<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.MaxLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxLines(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.MaxLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxLines<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.MaxLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxLinesChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.MaxLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxLinesChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.MaxLinesProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1738,6 +2362,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.TextAlignmentProperty
 
     /// <summary>
@@ -1832,6 +2504,54 @@ public static partial class TextBlockExtensions
     public static T OnTextAlignment<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Media.TextAlignment>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.TextAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextAlignment>> ObserveBindingTextAlignment(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextAlignment<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Media.TextAlignment>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextAlignmentChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2019,6 +2739,54 @@ public static partial class TextBlockExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextWrapping>> ObserveBindingTextWrapping(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextWrappingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextWrapping<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Media.TextWrapping>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextWrappingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextWrappingChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextWrappingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextWrappingChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextWrappingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.TextBlock.TextWrappingProperty"/> property value to <see cref="Avalonia.Media.TextWrapping.NoWrap"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -2152,6 +2920,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextTrimming>> ObserveBindingTextTrimming(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextTrimmingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextTrimming<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Media.TextTrimming>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextTrimmingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextTrimmingChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextTrimmingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextTrimmingChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextTrimmingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.TextDecorationsProperty
 
     /// <summary>
@@ -2246,6 +3062,54 @@ public static partial class TextBlockExtensions
     public static T OnTextDecorations<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<Avalonia.Media.TextDecorationCollection>> handler) where T : Avalonia.Controls.TextBlock
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.TextDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextDecorationCollection>> ObserveBindingTextDecorations(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextDecorations<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.TextDecorationCollection>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.TextDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextDecorationsChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.TextDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextDecorationsChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.TextDecorationsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2348,6 +3212,54 @@ public static partial class TextBlockExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFeatureCollection>> ObserveBindingFontFeatures(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontFeaturesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFeatures<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Media.FontFeatureCollection>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.FontFeaturesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFeaturesChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontFeaturesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFeaturesChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.FontFeaturesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBlock.InlinesProperty
 
     /// <summary>
@@ -2442,6 +3354,54 @@ public static partial class TextBlockExtensions
     public static T OnInlines<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<Avalonia.Controls.Documents.InlineCollection>> handler) where T : Avalonia.Controls.TextBlock
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBlock.InlinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBlock.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Documents.InlineCollection>> ObserveBindingInlines(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBlock.InlinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBlock.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInlines<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<BindingValue<Avalonia.Controls.Documents.InlineCollection>>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBlock.InlinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBlock.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInlinesChanged(this Avalonia.Controls.TextBlock obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.InlinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBlock.InlinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInlinesChanged<T>(this T obj, Action<Avalonia.Controls.TextBlock, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBlock
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBlock.InlinesProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TextBox.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TextBox.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsInactiveSelectionHighlightEnabled(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsInactiveSelectionHighlightEnabled<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsInactiveSelectionHighlightEnabledChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsInactiveSelectionHighlightEnabledChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.IsInactiveSelectionHighlightEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TextBoxExtensions
     public static T OnClearSelectionOnLostFocus<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingClearSelectionOnLostFocus(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClearSelectionOnLostFocus<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClearSelectionOnLostFocusChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClearSelectionOnLostFocusChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.ClearSelectionOnLostFocusProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.AcceptsReturnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAcceptsReturn(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.AcceptsReturnProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.AcceptsReturnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAcceptsReturn<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.AcceptsReturnProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.AcceptsReturnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAcceptsReturnChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.AcceptsReturnProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.AcceptsReturnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAcceptsReturnChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.AcceptsReturnProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.AcceptsTabProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class TextBoxExtensions
     public static T OnAcceptsTab<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.AcceptsTabProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.AcceptsTabProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAcceptsTab(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.AcceptsTabProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.AcceptsTabProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAcceptsTab<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.AcceptsTabProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.AcceptsTabProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAcceptsTabChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.AcceptsTabProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.AcceptsTabProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAcceptsTabChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.AcceptsTabProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingCaretIndex(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CaretIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretIndex<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CaretIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretIndexChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CaretIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretIndexChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CaretIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.IsReadOnlyProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class TextBoxExtensions
     public static T OnIsReadOnly<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsReadOnly(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsReadOnly<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsReadOnlyChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsReadOnlyChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.IsReadOnlyProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Char>> ObserveBindingPasswordChar(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.PasswordCharProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPasswordChar<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Char>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.PasswordCharProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePasswordCharChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.PasswordCharProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPasswordCharChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.PasswordCharProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.SelectionBrushProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class TextBoxExtensions
     public static T OnSelectionBrush<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.SelectionBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSelectionBrush(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionBrush<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionBrushChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionBrushChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionBrushProperty);
         handler(obj, observable);
         return obj;
     }
@@ -888,6 +1272,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSelectionForegroundBrush(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionForegroundBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionForegroundBrush<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionForegroundBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionForegroundBrushChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionForegroundBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionForegroundBrushChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionForegroundBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.CaretBrushProperty
 
     /// <summary>
@@ -982,6 +1414,54 @@ public static partial class TextBoxExtensions
     public static T OnCaretBrush<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.CaretBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingCaretBrush(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CaretBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretBrush<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CaretBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretBrushChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CaretBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretBrushChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CaretBrushProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1084,6 +1564,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingCaretBlinkInterval(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CaretBlinkIntervalProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretBlinkInterval<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CaretBlinkIntervalProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretBlinkIntervalChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CaretBlinkIntervalProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretBlinkIntervalChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CaretBlinkIntervalProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.SelectionStartProperty
 
     /// <summary>
@@ -1178,6 +1706,54 @@ public static partial class TextBoxExtensions
     public static T OnSelectionStart<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Int32>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.SelectionStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectionStart(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionStart<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionStartChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionStartChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionStartProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1280,6 +1856,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectionEnd(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionEnd<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.SelectionEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionEndChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionEndChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.SelectionEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.MaxLengthProperty
 
     /// <summary>
@@ -1374,6 +1998,54 @@ public static partial class TextBoxExtensions
     public static T OnMaxLength<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Int32>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.MaxLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxLength(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.MaxLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxLength<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.MaxLengthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxLengthChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.MaxLengthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.MaxLengthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxLengthChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.MaxLengthProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1476,6 +2148,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxLines(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.MaxLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxLines<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.MaxLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxLinesChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.MaxLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.MaxLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxLinesChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.MaxLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.MinLinesProperty
 
     /// <summary>
@@ -1570,6 +2290,54 @@ public static partial class TextBoxExtensions
     public static T OnMinLines<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Int32>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.MinLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.MinLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinLines(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.MinLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.MinLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinLines<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.MinLinesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.MinLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinLinesChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.MinLinesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.MinLinesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinLinesChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.MinLinesProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1672,6 +2440,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty
 
     /// <summary>
@@ -1766,6 +2582,54 @@ public static partial class TextBoxExtensions
     public static T OnHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<Avalonia.Layout.HorizontalAlignment>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>> ObserveBindingHorizontalContentAlignment(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalContentAlignment<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<Avalonia.Layout.HorizontalAlignment>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalContentAlignmentChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.HorizontalContentAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1917,6 +2781,54 @@ public static partial class TextBoxExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>> ObserveBindingVerticalContentAlignment(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalContentAlignment<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<Avalonia.Layout.VerticalAlignment>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalContentAlignmentChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.VerticalContentAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.VerticalContentAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalContentAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.VerticalContentAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.TextBox.VerticalContentAlignmentProperty"/> property value to <see cref="Avalonia.Layout.VerticalAlignment.Stretch"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -2062,6 +2974,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingWatermark(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWatermark<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWatermarkChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.WatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.WatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWatermarkChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.WatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.UseFloatingWatermarkProperty
 
     /// <summary>
@@ -2156,6 +3116,54 @@ public static partial class TextBoxExtensions
     public static T OnUseFloatingWatermark<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.UseFloatingWatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseFloatingWatermark(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.UseFloatingWatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseFloatingWatermark<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.UseFloatingWatermarkProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseFloatingWatermarkChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.UseFloatingWatermarkProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.UseFloatingWatermarkProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseFloatingWatermarkChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.UseFloatingWatermarkProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2258,6 +3266,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.NewLineProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingNewLine(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.NewLineProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.NewLineProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingNewLine<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.NewLineProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.NewLineProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveNewLineChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.NewLineProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.NewLineProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnNewLineChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.NewLineProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.InnerLeftContentProperty
 
     /// <summary>
@@ -2352,6 +3408,54 @@ public static partial class TextBoxExtensions
     public static T OnInnerLeftContent<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<System.Object>> handler) where T : Avalonia.Controls.TextBox
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.InnerLeftContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingInnerLeftContent(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.InnerLeftContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInnerLeftContent<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.InnerLeftContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInnerLeftContentChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.InnerLeftContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.InnerLeftContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInnerLeftContentChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.InnerLeftContentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2454,6 +3558,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingInnerRightContent(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.InnerRightContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingInnerRightContent<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.InnerRightContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveInnerRightContentChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.InnerRightContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.InnerRightContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnInnerRightContentChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.InnerRightContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.RevealPasswordProperty
 
     /// <summary>
@@ -2552,6 +3704,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingRevealPassword(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.RevealPasswordProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRevealPassword<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.RevealPasswordProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRevealPasswordChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.RevealPasswordProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRevealPasswordChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.RevealPasswordProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.CanCutProperty
 
     /// <summary>
@@ -2592,6 +3792,52 @@ public static partial class TextBoxExtensions
     public static Avalonia.Controls.TextBox OnCanCut(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.CanCutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CanCutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanCut(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CanCutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CanCutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnBindingCanCut(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CanCutProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CanCutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanCutChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanCutProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CanCutProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnCanCutChanged(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanCutProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2640,6 +3886,52 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanCopy(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CanCopyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnBindingCanCopy(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CanCopyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanCopyChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanCopyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CanCopyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnCanCopyChanged(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanCopyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.CanPasteProperty
 
     /// <summary>
@@ -2680,6 +3972,52 @@ public static partial class TextBoxExtensions
     public static Avalonia.Controls.TextBox OnCanPaste(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.CanPasteProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CanPasteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanPaste(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CanPasteProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CanPasteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnBindingCanPaste(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CanPasteProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CanPasteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanPasteChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanPasteProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CanPasteProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnCanPasteChanged(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanPasteProperty);
         handler(obj, observable);
         return obj;
     }
@@ -2782,6 +4120,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.IsUndoEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsUndoEnabled(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.IsUndoEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.IsUndoEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsUndoEnabled<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.IsUndoEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.IsUndoEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsUndoEnabledChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.IsUndoEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.IsUndoEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsUndoEnabledChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.IsUndoEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.UndoLimitProperty
 
     /// <summary>
@@ -2880,6 +4266,54 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.UndoLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingUndoLimit(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.UndoLimitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.UndoLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUndoLimit<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.UndoLimitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.UndoLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUndoLimitChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.UndoLimitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.UndoLimitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUndoLimitChanged<T>(this T obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TextBox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.UndoLimitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.CanUndoProperty
 
     /// <summary>
@@ -2924,6 +4358,52 @@ public static partial class TextBoxExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CanUndoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUndo(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CanUndoProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CanUndoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnBindingCanUndo(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CanUndoProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CanUndoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUndoChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanUndoProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CanUndoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnCanUndoChanged(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanUndoProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TextBox.CanRedoProperty
 
     /// <summary>
@@ -2964,6 +4444,52 @@ public static partial class TextBoxExtensions
     public static Avalonia.Controls.TextBox OnCanRedo(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TextBox.CanRedoProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TextBox.CanRedoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanRedo(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TextBox.CanRedoProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TextBox.CanRedoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnBindingCanRedo(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TextBox.CanRedoProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TextBox.CanRedoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanRedoChanged(this Avalonia.Controls.TextBox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanRedoProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TextBox.CanRedoProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TextBox OnCanRedoChanged(this Avalonia.Controls.TextBox obj, Action<Avalonia.Controls.TextBox, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TextBox.CanRedoProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TextDecoration.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TextDecoration.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class TextDecorationExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.LocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextDecorationLocation>> ObserveBindingLocation(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.LocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.LocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLocation<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<Avalonia.Media.TextDecorationLocation>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.LocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.LocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLocationChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.LocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.LocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLocationChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.LocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Media.TextDecoration.LocationProperty"/> property value to <see cref="Avalonia.Media.TextDecorationLocation.Underline"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -250,6 +298,54 @@ public static partial class TextDecorationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingStroke(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStroke<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty
 
     /// <summary>
@@ -344,6 +440,54 @@ public static partial class TextDecorationExtensions
     public static T OnStrokeThicknessUnit<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<Avalonia.Media.TextDecorationUnit>> handler) where T : Avalonia.Media.TextDecoration
     {
         var observable = obj.GetObservable(Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextDecorationUnit>> ObserveBindingStrokeThicknessUnit(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeThicknessUnit<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<Avalonia.Media.TextDecorationUnit>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeThicknessUnitChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeThicknessUnitChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeThicknessUnitProperty);
         handler(obj, observable);
         return obj;
     }
@@ -482,6 +626,54 @@ public static partial class TextDecorationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>> ObserveBindingStrokeDashArray(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeDashArrayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeDashArray<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeDashArrayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeDashArrayChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeDashArrayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashArrayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeDashArrayChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeDashArrayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TextDecoration.StrokeDashOffsetProperty
 
     /// <summary>
@@ -576,6 +768,54 @@ public static partial class TextDecorationExtensions
     public static T OnStrokeDashOffset<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<System.Double>> handler) where T : Avalonia.Media.TextDecoration
     {
         var observable = obj.GetObservable(Avalonia.Media.TextDecoration.StrokeDashOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStrokeDashOffset(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeDashOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeDashOffset<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeDashOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeDashOffsetChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeDashOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeDashOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeDashOffsetChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeDashOffsetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -678,6 +918,54 @@ public static partial class TextDecorationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStrokeThickness(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeThickness<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeThicknessChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeThicknessProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeThicknessProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeThicknessChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeThicknessProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TextDecoration.StrokeLineCapProperty
 
     /// <summary>
@@ -772,6 +1060,54 @@ public static partial class TextDecorationExtensions
     public static T OnStrokeLineCap<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<Avalonia.Media.PenLineCap>> handler) where T : Avalonia.Media.TextDecoration
     {
         var observable = obj.GetObservable(Avalonia.Media.TextDecoration.StrokeLineCapProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.PenLineCap>> ObserveBindingStrokeLineCap(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeLineCapProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeLineCap<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<Avalonia.Media.PenLineCap>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeLineCapProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeLineCapChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeLineCapProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeLineCapProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeLineCapChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeLineCapProperty);
         handler(obj, observable);
         return obj;
     }
@@ -910,6 +1246,54 @@ public static partial class TextDecorationExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingStrokeOffset(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeOffset<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeOffsetChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeOffsetChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty
 
     /// <summary>
@@ -1004,6 +1388,54 @@ public static partial class TextDecorationExtensions
     public static T OnStrokeOffsetUnit<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<Avalonia.Media.TextDecorationUnit>> handler) where T : Avalonia.Media.TextDecoration
     {
         var observable = obj.GetObservable(Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextDecorationUnit>> ObserveBindingStrokeOffsetUnit(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStrokeOffsetUnit<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<BindingValue<Avalonia.Media.TextDecorationUnit>>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStrokeOffsetUnitChanged(this Avalonia.Media.TextDecoration obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStrokeOffsetUnitChanged<T>(this T obj, Action<Avalonia.Media.TextDecoration, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TextDecoration
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TextDecoration.StrokeOffsetUnitProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TextElement.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TextElement.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TextElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Documents.TextElement.FontFamilyProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TextElementExtensions
     public static T OnFontFamily<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<Avalonia.Media.FontFamily>> handler) where T : Avalonia.Controls.Documents.TextElement
     {
         var observable = obj.GetObservable(Avalonia.Controls.Documents.TextElement.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFamily>> ObserveBindingFontFamily(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFamily<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.FontFamily>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontFamilyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFamilyChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontFamilyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFamilyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFamilyChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontFamilyProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TextElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontFeatureCollection>> ObserveBindingFontFeatures(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontFeaturesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontFeatures<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.FontFeatureCollection>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontFeaturesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontFeaturesChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontFeaturesProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontFeaturesProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontFeaturesChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontFeaturesProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Documents.TextElement.FontSizeProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class TextElementExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingFontSize(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontSize<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontSizeChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontSizeChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Documents.TextElement.FontStyleProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class TextElementExtensions
     public static T OnFontStyle<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<Avalonia.Media.FontStyle>> handler) where T : Avalonia.Controls.Documents.TextElement
     {
         var observable = obj.GetObservable(Avalonia.Controls.Documents.TextElement.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStyle>> ObserveBindingFontStyle(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStyle<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.FontStyle>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontStyleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStyleChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontStyleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStyleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStyleChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontStyleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -626,6 +866,54 @@ public static partial class TextElementExtensions
     public static T OnFontWeight<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<Avalonia.Media.FontWeight>> handler) where T : Avalonia.Controls.Documents.TextElement
     {
         var observable = obj.GetObservable(Avalonia.Controls.Documents.TextElement.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontWeight>> ObserveBindingFontWeight(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontWeight<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.FontWeight>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontWeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontWeightChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontWeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontWeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontWeightChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontWeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -945,6 +1233,54 @@ public static partial class TextElementExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FontStretch>> ObserveBindingFontStretch(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFontStretch<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.FontStretch>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFontStretchChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.FontStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFontStretchChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.FontStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Documents.TextElement.FontStretchProperty"/> property value to <see cref="Avalonia.Media.FontStretch.UltraCondensed"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1146,6 +1482,54 @@ public static partial class TextElementExtensions
     public static T OnForeground<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Controls.Documents.TextElement
     {
         var observable = obj.GetObservable(Avalonia.Controls.Documents.TextElement.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingForeground(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Documents.TextElement.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingForeground<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Documents.TextElement.ForegroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Documents.TextElement.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveForegroundChanged(this Avalonia.Controls.Documents.TextElement obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.ForegroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Documents.TextElement.ForegroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnForegroundChanged<T>(this T obj, Action<Avalonia.Controls.Documents.TextElement, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Documents.TextElement
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Documents.TextElement.ForegroundProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TextPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TextPresenter.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowSelectionHighlight(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowSelectionHighlight<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowSelectionHighlightChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowSelectionHighlightChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.ShowSelectionHighlightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TextPresenterExtensions
     public static T OnCaretIndex<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingCaretIndex(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretIndex<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretIndexChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretIndexChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.CaretIndexProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingRevealPassword(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRevealPassword<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRevealPasswordChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRevealPasswordChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.RevealPasswordProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class TextPresenterExtensions
     public static T OnPasswordChar<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<System.Char>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Char>> ObserveBindingPasswordChar(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPasswordChar<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Char>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePasswordCharChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPasswordCharChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.PasswordCharProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSelectionBrush(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionBrush<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionBrushChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionBrushChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty
 
     /// <summary>
@@ -590,6 +830,54 @@ public static partial class TextPresenterExtensions
     public static T OnSelectionForegroundBrush<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingSelectionForegroundBrush(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionForegroundBrush<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionForegroundBrushChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionForegroundBrushChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionForegroundBrushProperty);
         handler(obj, observable);
         return obj;
     }
@@ -692,6 +980,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingCaretBrush(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretBrush<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretBrushChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretBrushChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBrushProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty
 
     /// <summary>
@@ -786,6 +1122,54 @@ public static partial class TextPresenterExtensions
     public static T OnCaretBlinkInterval<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<System.TimeSpan>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingCaretBlinkInterval(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCaretBlinkInterval<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCaretBlinkIntervalChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCaretBlinkIntervalChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.CaretBlinkIntervalProperty);
         handler(obj, observable);
         return obj;
     }
@@ -888,6 +1272,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectionStart(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionStart<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionStartChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionStartChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionStartProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty
 
     /// <summary>
@@ -982,6 +1414,54 @@ public static partial class TextPresenterExtensions
     public static T OnSelectionEnd<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSelectionEnd(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionEnd<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionEndChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionEndChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.SelectionEndProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1084,6 +1564,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingText(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingText<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.TextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.TextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.TextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty
 
     /// <summary>
@@ -1178,6 +1706,54 @@ public static partial class TextPresenterExtensions
     public static T OnPreeditText<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<System.String>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingPreeditText(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPreeditText<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePreeditTextChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPreeditTextChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1280,6 +1856,54 @@ public static partial class TextPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.Int32>>> ObserveBindingPreeditTextCursorPosition(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPreeditTextCursorPosition<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<System.Nullable<System.Int32>>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePreeditTextCursorPositionChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPreeditTextCursorPositionChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.PreeditTextCursorPositionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty
 
     /// <summary>
@@ -1374,6 +1998,54 @@ public static partial class TextPresenterExtensions
     public static T OnBackground<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingBackground(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBackground<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBackgroundChanged(this Avalonia.Controls.Presenters.TextPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBackgroundChanged<T>(this T obj, Action<Avalonia.Controls.Presenters.TextPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Presenters.TextPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Presenters.TextPresenter.BackgroundProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TickBar.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TickBar.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TickBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingFill(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.FillProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFill<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.FillProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFillChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.FillProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.FillProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFillChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.FillProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TickBar.MinimumProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TickBarExtensions
     public static T OnMinimum<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<System.Double>> handler) where T : Avalonia.Controls.TickBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.TickBar.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinimum(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinimum<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinimumChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinimumChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.MinimumProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TickBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaximum(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaximum<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaximumChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaximumChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TickBar.TickFrequencyProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class TickBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingTickFrequency(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.TickFrequencyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTickFrequency<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.TickFrequencyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTickFrequencyChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.TickFrequencyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.TickFrequencyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTickFrequencyChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.TickFrequencyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TickBar.OrientationProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class TickBarExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Controls.TickBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.TickBar.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.OrientationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -618,6 +858,54 @@ public static partial class TickBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>> ObserveBindingTicks(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.TicksProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTicks<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<Avalonia.Collections.AvaloniaList<System.Double>>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.TicksProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTicksChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.TicksProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.TicksProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTicksChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.TicksProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TickBar.IsDirectionReversedProperty
 
     /// <summary>
@@ -716,6 +1004,54 @@ public static partial class TickBarExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDirectionReversed(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.IsDirectionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDirectionReversed<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.IsDirectionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDirectionReversedChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.IsDirectionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDirectionReversedChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.IsDirectionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TickBar.PlacementProperty
 
     /// <summary>
@@ -810,6 +1146,54 @@ public static partial class TickBarExtensions
     public static T OnPlacement<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<Avalonia.Controls.TickBarPlacement>> handler) where T : Avalonia.Controls.TickBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.TickBar.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.TickBarPlacement>> ObserveBindingPlacement(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacement<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<Avalonia.Controls.TickBarPlacement>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.PlacementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -956,6 +1340,54 @@ public static partial class TickBarExtensions
     public static T OnReservedSpace<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<Avalonia.Rect>> handler) where T : Avalonia.Controls.TickBar
     {
         var observable = obj.GetObservable(Avalonia.Controls.TickBar.ReservedSpaceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TickBar.ReservedSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Rect>> ObserveBindingReservedSpace(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TickBar.ReservedSpaceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TickBar.ReservedSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingReservedSpace<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<BindingValue<Avalonia.Rect>>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TickBar.ReservedSpaceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TickBar.ReservedSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveReservedSpaceChanged(this Avalonia.Controls.TickBar obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.ReservedSpaceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TickBar.ReservedSpaceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnReservedSpaceChanged<T>(this T obj, Action<Avalonia.Controls.TickBar, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TickBar
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TickBar.ReservedSpaceProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TileBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TileBrush.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class TileBrushExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TileBrush.AlignmentXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.AlignmentX>> ObserveBindingAlignmentX(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TileBrush.AlignmentXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TileBrush.AlignmentXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignmentX<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<BindingValue<Avalonia.Media.AlignmentX>>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TileBrush.AlignmentXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TileBrush.AlignmentXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignmentXChanged(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.AlignmentXProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TileBrush.AlignmentXProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignmentXChanged<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.AlignmentXProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Media.TileBrush.AlignmentXProperty"/> property value to <see cref="Avalonia.Media.AlignmentX.Left"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -234,6 +282,54 @@ public static partial class TileBrushExtensions
     public static T OnAlignmentY<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<Avalonia.Media.AlignmentY>> handler) where T : Avalonia.Media.TileBrush
     {
         var observable = obj.GetObservable(Avalonia.Media.TileBrush.AlignmentYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TileBrush.AlignmentYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.AlignmentY>> ObserveBindingAlignmentY(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TileBrush.AlignmentYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TileBrush.AlignmentYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAlignmentY<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<BindingValue<Avalonia.Media.AlignmentY>>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TileBrush.AlignmentYProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TileBrush.AlignmentYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAlignmentYChanged(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.AlignmentYProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TileBrush.AlignmentYProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAlignmentYChanged<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.AlignmentYProperty);
         handler(obj, observable);
         return obj;
     }
@@ -372,6 +468,54 @@ public static partial class TileBrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TileBrush.DestinationRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativeRect>> ObserveBindingDestinationRect(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TileBrush.DestinationRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TileBrush.DestinationRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDestinationRect<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<BindingValue<Avalonia.RelativeRect>>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TileBrush.DestinationRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TileBrush.DestinationRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDestinationRectChanged(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.DestinationRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TileBrush.DestinationRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDestinationRectChanged<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.DestinationRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TileBrush.SourceRectProperty
 
     /// <summary>
@@ -470,6 +614,54 @@ public static partial class TileBrushExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TileBrush.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativeRect>> ObserveBindingSourceRect(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TileBrush.SourceRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TileBrush.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSourceRect<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<BindingValue<Avalonia.RelativeRect>>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TileBrush.SourceRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TileBrush.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSourceRectChanged(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.SourceRectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TileBrush.SourceRectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSourceRectChanged<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.SourceRectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TileBrush.StretchProperty
 
     /// <summary>
@@ -564,6 +756,54 @@ public static partial class TileBrushExtensions
     public static T OnStretch<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<Avalonia.Media.Stretch>> handler) where T : Avalonia.Media.TileBrush
     {
         var observable = obj.GetObservable(Avalonia.Media.TileBrush.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TileBrush.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Stretch>> ObserveBindingStretch(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TileBrush.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TileBrush.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStretch<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<BindingValue<Avalonia.Media.Stretch>>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TileBrush.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TileBrush.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStretchChanged(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TileBrush.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStretchChanged<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.StretchProperty);
         handler(obj, observable);
         return obj;
     }
@@ -710,6 +950,54 @@ public static partial class TileBrushExtensions
     public static T OnTileMode<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<Avalonia.Media.TileMode>> handler) where T : Avalonia.Media.TileBrush
     {
         var observable = obj.GetObservable(Avalonia.Media.TileBrush.TileModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TileBrush.TileModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TileMode>> ObserveBindingTileMode(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TileBrush.TileModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TileBrush.TileModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTileMode<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<BindingValue<Avalonia.Media.TileMode>>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TileBrush.TileModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TileBrush.TileModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTileModeChanged(this Avalonia.Media.TileBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.TileModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TileBrush.TileModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTileModeChanged<T>(this T obj, Action<Avalonia.Media.TileBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Media.TileBrush
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TileBrush.TileModeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TimePicker.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TimePicker.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TimePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePicker.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinuteIncrement(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePicker.MinuteIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePicker.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinuteIncrement<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePicker.MinuteIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePicker.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinuteIncrementChanged(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.MinuteIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePicker.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinuteIncrementChanged<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.MinuteIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TimePicker.SecondIncrementProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TimePickerExtensions
     public static T OnSecondIncrement<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<System.Int32>> handler) where T : Avalonia.Controls.TimePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.TimePicker.SecondIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePicker.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSecondIncrement(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePicker.SecondIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePicker.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSecondIncrement<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePicker.SecondIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePicker.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSecondIncrementChanged(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.SecondIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePicker.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSecondIncrementChanged<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.SecondIncrementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TimePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePicker.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingClockIdentifier(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePicker.ClockIdentifierProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePicker.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClockIdentifier<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePicker.ClockIdentifierProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePicker.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClockIdentifierChanged(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.ClockIdentifierProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePicker.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClockIdentifierChanged<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.ClockIdentifierProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TimePicker.UseSecondsProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class TimePickerExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePicker.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseSeconds(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePicker.UseSecondsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePicker.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseSeconds<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePicker.UseSecondsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePicker.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseSecondsChanged(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.UseSecondsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePicker.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseSecondsChanged<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.UseSecondsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TimePicker.SelectedTimeProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class TimePickerExtensions
     public static T OnSelectedTime<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<System.Nullable<System.TimeSpan>>> handler) where T : Avalonia.Controls.TimePicker
     {
         var observable = obj.GetObservable(Avalonia.Controls.TimePicker.SelectedTimeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePicker.SelectedTimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.TimeSpan>>> ObserveBindingSelectedTime(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePicker.SelectedTimeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePicker.SelectedTimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedTime<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<BindingValue<System.Nullable<System.TimeSpan>>>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePicker.SelectedTimeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePicker.SelectedTimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedTimeChanged(this Avalonia.Controls.TimePicker obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.SelectedTimeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePicker.SelectedTimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedTimeChanged<T>(this T obj, Action<Avalonia.Controls.TimePicker, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePicker
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePicker.SelectedTimeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TimePickerPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TimePickerPresenter.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TimePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMinuteIncrement(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinuteIncrement<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinuteIncrementChanged(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinuteIncrementChanged<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.MinuteIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TimePickerPresenterExtensions
     public static T OnSecondIncrement<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<System.Int32>> handler) where T : Avalonia.Controls.TimePickerPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingSecondIncrement(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSecondIncrement<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSecondIncrementChanged(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSecondIncrementChanged<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.SecondIncrementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TimePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingClockIdentifier(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClockIdentifier<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClockIdentifierChanged(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClockIdentifierChanged<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.ClockIdentifierProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TimePickerPresenter.UseSecondsProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class TimePickerPresenterExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingUseSeconds(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.UseSecondsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingUseSeconds<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.UseSecondsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveUseSecondsChanged(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.UseSecondsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.UseSecondsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnUseSecondsChanged<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.UseSecondsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TimePickerPresenter.TimeProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class TimePickerPresenterExtensions
     public static T OnTime<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<System.TimeSpan>> handler) where T : Avalonia.Controls.TimePickerPresenter
     {
         var observable = obj.GetObservable(Avalonia.Controls.TimePickerPresenter.TimeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.TimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingTime(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.TimeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TimePickerPresenter.TimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTime<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TimePickerPresenter.TimeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.TimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTimeChanged(this Avalonia.Controls.TimePickerPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.TimeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TimePickerPresenter.TimeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTimeChanged<T>(this T obj, Action<Avalonia.Controls.TimePickerPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TimePickerPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TimePickerPresenter.TimeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ToggleButton.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ToggleButton.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ToggleButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.Boolean>>> ObserveBindingIsChecked(this Avalonia.Controls.Primitives.ToggleButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsChecked<T>(this T obj, Action<Avalonia.Controls.Primitives.ToggleButton, IObservable<BindingValue<System.Nullable<System.Boolean>>>> handler) where T : Avalonia.Controls.Primitives.ToggleButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsCheckedChanged(this Avalonia.Controls.Primitives.ToggleButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsCheckedChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ToggleButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ToggleButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ToggleButton.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ToggleButtonExtensions
     public static T OnIsThreeState<T>(this T obj, Action<Avalonia.Controls.Primitives.ToggleButton, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.ToggleButton
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsThreeState(this Avalonia.Controls.Primitives.ToggleButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsThreeState<T>(this T obj, Action<Avalonia.Controls.Primitives.ToggleButton, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.ToggleButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsThreeStateChanged(this Avalonia.Controls.Primitives.ToggleButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsThreeStateChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.ToggleButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.ToggleButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.ToggleButton.IsThreeStateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ToggleSplitButton.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ToggleSplitButton.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ToggleSplitButtonExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToggleSplitButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsChecked(this Avalonia.Controls.ToggleSplitButton obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToggleSplitButton.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToggleSplitButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsChecked<T>(this T obj, Action<Avalonia.Controls.ToggleSplitButton, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.ToggleSplitButton
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToggleSplitButton.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToggleSplitButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsCheckedChanged(this Avalonia.Controls.ToggleSplitButton obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSplitButton.IsCheckedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToggleSplitButton.IsCheckedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsCheckedChanged<T>(this T obj, Action<Avalonia.Controls.ToggleSplitButton, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ToggleSplitButton
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSplitButton.IsCheckedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToggleSplitButton.IsCheckedChangedEvent
 
     /// <summary>

--- a/src/NXUI/Generated/Extensions/ToggleSwitch.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ToggleSwitch.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ToggleSwitchExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingOffContent(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OffContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOffContent<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OffContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffContentChanged(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OffContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOffContentChanged<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OffContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class ToggleSwitchExtensions
     public static T OnOffContentTemplate<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler) where T : Avalonia.Controls.ToggleSwitch
     {
         var observable = obj.GetObservable(Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingOffContentTemplate(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOffContentTemplate<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffContentTemplateChanged(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOffContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OffContentTemplateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class ToggleSwitchExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingOnContent(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OnContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOnContent<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OnContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOnContentChanged(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OnContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOnContentChanged<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OnContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class ToggleSwitchExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingOnContentTemplate(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOnContentTemplate<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOnContentTemplateChanged(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOnContentTemplateChanged<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.OnContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class ToggleSwitchExtensions
     public static T OnKnobTransitions<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<Avalonia.Animation.Transitions>> handler) where T : Avalonia.Controls.ToggleSwitch
     {
         var observable = obj.GetObservable(Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.Transitions>> ObserveBindingKnobTransitions(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingKnobTransitions<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<BindingValue<Avalonia.Animation.Transitions>>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveKnobTransitionsChanged(this Avalonia.Controls.ToggleSwitch obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnKnobTransitionsChanged<T>(this T obj, Action<Avalonia.Controls.ToggleSwitch, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.ToggleSwitch
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToggleSwitch.KnobTransitionsProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/ToolTip.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/ToolTip.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class ToolTipExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.TipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingTip(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.TipProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.TipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTip<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.TipProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.TipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTipChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.TipProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.TipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTipChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.TipProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToolTip.IsOpenProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class ToolTipExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsOpen(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsOpen<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsOpenChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.IsOpenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.IsOpenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsOpenChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.IsOpenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToolTip.PlacementProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class ToolTipExtensions
     public static T OnPlacement<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<Avalonia.Controls.PlacementMode>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ToolTip.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.PlacementMode>> ObserveBindingPlacement(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPlacement<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.PlacementMode>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.PlacementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePlacementChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.PlacementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.PlacementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPlacementChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.PlacementProperty);
         handler(obj, observable);
         return obj;
     }
@@ -590,6 +734,54 @@ public static partial class ToolTipExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalOffset(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalOffset<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalOffsetChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.HorizontalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.HorizontalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.HorizontalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToolTip.VerticalOffsetProperty
 
     /// <summary>
@@ -684,6 +876,54 @@ public static partial class ToolTipExtensions
     public static T OnVerticalOffset<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Double>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ToolTip.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalOffset(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalOffset<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.VerticalOffsetProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalOffsetChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.VerticalOffsetProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.VerticalOffsetProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalOffsetChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.VerticalOffsetProperty);
         handler(obj, observable);
         return obj;
     }
@@ -786,6 +1026,54 @@ public static partial class ToolTipExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>> ObserveBindingCustomPopupPlacementCallback(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCustomPopupPlacementCallback<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Controls.Primitives.PopupPositioning.CustomPopupPlacementCallback>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCustomPopupPlacementCallbackChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCustomPopupPlacementCallbackChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.CustomPopupPlacementCallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToolTip.ShowDelayProperty
 
     /// <summary>
@@ -880,6 +1168,54 @@ public static partial class ToolTipExtensions
     public static T OnShowDelay<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ToolTip.ShowDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingShowDelay(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.ShowDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowDelay<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.ShowDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowDelayChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.ShowDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.ShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowDelayChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.ShowDelayProperty);
         handler(obj, observable);
         return obj;
     }
@@ -982,6 +1318,54 @@ public static partial class ToolTipExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.BetweenShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingBetweenShowDelay(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.BetweenShowDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.BetweenShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingBetweenShowDelay<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.BetweenShowDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.BetweenShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBetweenShowDelayChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.BetweenShowDelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.BetweenShowDelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBetweenShowDelayChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.BetweenShowDelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToolTip.ShowOnDisabledProperty
 
     /// <summary>
@@ -1080,6 +1464,54 @@ public static partial class ToolTipExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.ShowOnDisabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowOnDisabled(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.ShowOnDisabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.ShowOnDisabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowOnDisabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.ShowOnDisabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.ShowOnDisabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowOnDisabledChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.ShowOnDisabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.ShowOnDisabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowOnDisabledChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.ShowOnDisabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.ToolTip.ServiceEnabledProperty
 
     /// <summary>
@@ -1174,6 +1606,54 @@ public static partial class ToolTipExtensions
     public static T OnServiceEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.ToolTip.ServiceEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.ToolTip.ServiceEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingServiceEnabled(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.ToolTip.ServiceEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.ToolTip.ServiceEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingServiceEnabled<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.ToolTip.ServiceEnabledProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.ToolTip.ServiceEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveServiceEnabledChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.ServiceEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.ToolTip.ServiceEnabledProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnServiceEnabledChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.ToolTip.ServiceEnabledProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TopLevel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TopLevel.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class TopLevelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.ClientSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Size>> ObserveBindingClientSize(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.ClientSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.ClientSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TopLevel OnBindingClientSize(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<Avalonia.Size>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.ClientSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.ClientSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClientSizeChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.ClientSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.ClientSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TopLevel OnClientSizeChanged(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.ClientSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TopLevel.FrameSizeProperty
 
     /// <summary>
@@ -90,6 +136,52 @@ public static partial class TopLevelExtensions
     public static Avalonia.Controls.TopLevel OnFrameSize(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<System.Nullable<Avalonia.Size>>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TopLevel.FrameSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.FrameSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<Avalonia.Size>>> ObserveBindingFrameSize(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.FrameSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.FrameSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TopLevel OnBindingFrameSize(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<System.Nullable<Avalonia.Size>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.FrameSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.FrameSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFrameSizeChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.FrameSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.FrameSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TopLevel OnFrameSizeChanged(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.FrameSizeProperty);
         handler(obj, observable);
         return obj;
     }
@@ -192,6 +284,54 @@ public static partial class TopLevelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.PointerOverElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Input.IInputElement>> ObserveBindingPointerOverElement(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.PointerOverElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.PointerOverElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPointerOverElement<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<Avalonia.Input.IInputElement>>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.PointerOverElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.PointerOverElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePointerOverElementChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.PointerOverElementProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.PointerOverElementProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPointerOverElementChanged<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.PointerOverElementProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TopLevel.TransparencyLevelHintProperty
 
     /// <summary>
@@ -290,6 +430,54 @@ public static partial class TopLevelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.TransparencyLevelHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.Generic.IReadOnlyList<Avalonia.Controls.WindowTransparencyLevel>>> ObserveBindingTransparencyLevelHint(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.TransparencyLevelHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.TransparencyLevelHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransparencyLevelHint<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<System.Collections.Generic.IReadOnlyList<Avalonia.Controls.WindowTransparencyLevel>>>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.TransparencyLevelHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.TransparencyLevelHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransparencyLevelHintChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.TransparencyLevelHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.TransparencyLevelHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransparencyLevelHintChanged<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.TransparencyLevelHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty
 
     /// <summary>
@@ -330,6 +518,52 @@ public static partial class TopLevelExtensions
     public static Avalonia.Controls.TopLevel OnActualTransparencyLevel(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<Avalonia.Controls.WindowTransparencyLevel>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowTransparencyLevel>> ObserveBindingActualTransparencyLevel(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TopLevel OnBindingActualTransparencyLevel(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<Avalonia.Controls.WindowTransparencyLevel>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveActualTransparencyLevelChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TopLevel OnActualTransparencyLevelChanged(this Avalonia.Controls.TopLevel obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.ActualTransparencyLevelProperty);
         handler(obj, observable);
         return obj;
     }
@@ -432,6 +666,54 @@ public static partial class TopLevelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingTransparencyBackgroundFallback(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTransparencyBackgroundFallback<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTransparencyBackgroundFallbackChanged(this Avalonia.Controls.TopLevel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTransparencyBackgroundFallbackChanged<T>(this T obj, Action<Avalonia.Controls.TopLevel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TopLevel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.TransparencyBackgroundFallbackProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TopLevel.SystemBarColorProperty
 
     /// <summary>
@@ -530,6 +812,54 @@ public static partial class TopLevelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.SystemBarColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.SolidColorBrush>> ObserveBindingSystemBarColor(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.SystemBarColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.SystemBarColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSystemBarColor<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<Avalonia.Media.SolidColorBrush>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.SystemBarColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.SystemBarColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSystemBarColorChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.SystemBarColorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.SystemBarColorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSystemBarColorChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.SystemBarColorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty
 
     /// <summary>
@@ -624,6 +954,54 @@ public static partial class TopLevelExtensions
     public static T OnAutoSafeAreaPadding<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Control
     {
         var observable = obj.GetObservable(Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAutoSafeAreaPadding(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAutoSafeAreaPadding<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAutoSafeAreaPaddingChanged(this Avalonia.Controls.Control obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAutoSafeAreaPaddingChanged<T>(this T obj, Action<Avalonia.Controls.Control, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Control
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TopLevel.AutoSafeAreaPaddingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Track.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Track.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TrackExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinimum(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinimum<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinimumChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.MinimumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.MinimumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinimumChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.MinimumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Track.MaximumProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TrackExtensions
     public static T OnMaximum<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<System.Double>> handler) where T : Avalonia.Controls.Primitives.Track
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Track.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMaximum(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaximum<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.MaximumProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaximumChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.MaximumProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.MaximumProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaximumChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.MaximumProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TrackExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingValue(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingValue<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveValueChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Track.ViewportSizeProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class TrackExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingViewportSize(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.ViewportSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingViewportSize<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.ViewportSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveViewportSizeChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.ViewportSizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.ViewportSizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnViewportSizeChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.ViewportSizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Track.OrientationProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class TrackExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Controls.Primitives.Track
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Track.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.OrientationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -618,6 +858,54 @@ public static partial class TrackExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.ThumbProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.Thumb>> ObserveBindingThumb(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.ThumbProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.ThumbProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingThumb<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<Avalonia.Controls.Primitives.Thumb>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.ThumbProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.ThumbProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveThumbChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.ThumbProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.ThumbProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnThumbChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.ThumbProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Track.IncreaseButtonProperty
 
     /// <summary>
@@ -712,6 +1000,54 @@ public static partial class TrackExtensions
     public static T OnIncreaseButton<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<Avalonia.Controls.Button>> handler) where T : Avalonia.Controls.Primitives.Track
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Track.IncreaseButtonProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.IncreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Button>> ObserveBindingIncreaseButton(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.IncreaseButtonProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.IncreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIncreaseButton<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<Avalonia.Controls.Button>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.IncreaseButtonProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.IncreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIncreaseButtonChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.IncreaseButtonProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.IncreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIncreaseButtonChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.IncreaseButtonProperty);
         handler(obj, observable);
         return obj;
     }
@@ -814,6 +1150,54 @@ public static partial class TrackExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.DecreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Button>> ObserveBindingDecreaseButton(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.DecreaseButtonProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.DecreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDecreaseButton<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<Avalonia.Controls.Button>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.DecreaseButtonProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.DecreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDecreaseButtonChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.DecreaseButtonProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.DecreaseButtonProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDecreaseButtonChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.DecreaseButtonProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty
 
     /// <summary>
@@ -908,6 +1292,54 @@ public static partial class TrackExtensions
     public static T OnIsDirectionReversed<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.Track
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsDirectionReversed(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsDirectionReversed<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsDirectionReversedChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsDirectionReversedChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.IsDirectionReversedProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1010,6 +1442,54 @@ public static partial class TrackExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIgnoreThumbDrag(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIgnoreThumbDrag<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIgnoreThumbDragChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIgnoreThumbDragChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.IgnoreThumbDragProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.Track.DeferThumbDragProperty
 
     /// <summary>
@@ -1104,6 +1584,54 @@ public static partial class TrackExtensions
     public static T OnDeferThumbDrag<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Primitives.Track
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.Track.DeferThumbDragProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.Track.DeferThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingDeferThumbDrag(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.DeferThumbDragProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.Track.DeferThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDeferThumbDrag<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.Track.DeferThumbDragProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.Track.DeferThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDeferThumbDragChanged(this Avalonia.Controls.Primitives.Track obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.DeferThumbDragProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.Track.DeferThumbDragProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDeferThumbDragChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.Track, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.Track
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.Track.DeferThumbDragProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TransformGroup.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TransformGroup.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class TransformGroupExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TransformGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Transforms>> ObserveBindingChildren(this Avalonia.Media.TransformGroup obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TransformGroup.ChildrenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TransformGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.TransformGroup OnBindingChildren(this Avalonia.Media.TransformGroup obj, Action<Avalonia.Media.TransformGroup, IObservable<BindingValue<Avalonia.Media.Transforms>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TransformGroup.ChildrenProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TransformGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildrenChanged(this Avalonia.Media.TransformGroup obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TransformGroup.ChildrenProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TransformGroup.ChildrenProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.TransformGroup OnChildrenChanged(this Avalonia.Media.TransformGroup obj, Action<Avalonia.Media.TransformGroup, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TransformGroup.ChildrenProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/TransitionBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TransitionBase.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TransitionBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.TransitionBase.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingDuration(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.TransitionBase.DurationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.TransitionBase.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDuration<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.TransitionBase.DurationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.TransitionBase.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDurationChanged(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.DurationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.TransitionBase.DurationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDurationChanged<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.DurationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Animation.TransitionBase.DelayProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TransitionBaseExtensions
     public static T OnDelay<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<System.TimeSpan>> handler) where T : Avalonia.Animation.TransitionBase
     {
         var observable = obj.GetObservable(Avalonia.Animation.TransitionBase.DelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.TransitionBase.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.TimeSpan>> ObserveBindingDelay(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.TransitionBase.DelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.TransitionBase.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingDelay<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<BindingValue<System.TimeSpan>>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.TransitionBase.DelayProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.TransitionBase.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveDelayChanged(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.DelayProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.TransitionBase.DelayProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnDelayChanged<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.DelayProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TransitionBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.TransitionBase.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.Easings.Easing>> ObserveBindingEasing(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.TransitionBase.EasingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.TransitionBase.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingEasing<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<BindingValue<Avalonia.Animation.Easings.Easing>>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.TransitionBase.EasingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.TransitionBase.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEasingChanged(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.EasingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.TransitionBase.EasingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnEasingChanged<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.EasingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Animation.TransitionBase.PropertyProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class TransitionBaseExtensions
     public static T OnProperty<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<Avalonia.AvaloniaProperty>> handler) where T : Avalonia.Animation.TransitionBase
     {
         var observable = obj.GetObservable(Avalonia.Animation.TransitionBase.PropertyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Animation.TransitionBase.PropertyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.AvaloniaProperty>> ObserveBindingProperty(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Animation.TransitionBase.PropertyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Animation.TransitionBase.PropertyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingProperty<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<BindingValue<Avalonia.AvaloniaProperty>>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Animation.TransitionBase.PropertyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Animation.TransitionBase.PropertyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePropertyChanged(this Avalonia.Animation.TransitionBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.PropertyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Animation.TransitionBase.PropertyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPropertyChanged<T>(this T obj, Action<Avalonia.Animation.TransitionBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Animation.TransitionBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Animation.TransitionBase.PropertyProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TransitioningContentControl.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TransitioningContentControl.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TransitioningContentControlExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TransitioningContentControl.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Animation.IPageTransition>> ObserveBindingPageTransition(this Avalonia.Controls.TransitioningContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TransitioningContentControl.PageTransitionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TransitioningContentControl.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPageTransition<T>(this T obj, Action<Avalonia.Controls.TransitioningContentControl, IObservable<BindingValue<Avalonia.Animation.IPageTransition>>> handler) where T : Avalonia.Controls.TransitioningContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TransitioningContentControl.PageTransitionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TransitioningContentControl.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePageTransitionChanged(this Avalonia.Controls.TransitioningContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TransitioningContentControl.PageTransitionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TransitioningContentControl.PageTransitionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPageTransitionChanged<T>(this T obj, Action<Avalonia.Controls.TransitioningContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TransitioningContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TransitioningContentControl.PageTransitionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TransitioningContentControlExtensions
     public static T OnIsTransitionReversed<T>(this T obj, Action<Avalonia.Controls.TransitioningContentControl, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TransitioningContentControl
     {
         var observable = obj.GetObservable(Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsTransitionReversed(this Avalonia.Controls.TransitioningContentControl obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsTransitionReversed<T>(this T obj, Action<Avalonia.Controls.TransitioningContentControl, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TransitioningContentControl
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsTransitionReversedChanged(this Avalonia.Controls.TransitioningContentControl obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsTransitionReversedChanged<T>(this T obj, Action<Avalonia.Controls.TransitioningContentControl, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TransitioningContentControl
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TransitioningContentControl.IsTransitionReversedProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TranslateTransform.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TranslateTransform.Extensions.g.cs
@@ -99,6 +99,52 @@ public static partial class TranslateTransformExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TranslateTransform.XProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingX(this Avalonia.Media.TranslateTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TranslateTransform.XProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TranslateTransform.XProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.TranslateTransform OnBindingX(this Avalonia.Media.TranslateTransform obj, Action<Avalonia.Media.TranslateTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TranslateTransform.XProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TranslateTransform.XProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveXChanged(this Avalonia.Media.TranslateTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TranslateTransform.XProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TranslateTransform.XProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.TranslateTransform OnXChanged(this Avalonia.Media.TranslateTransform obj, Action<Avalonia.Media.TranslateTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TranslateTransform.XProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Media.TranslateTransform.YProperty
 
     /// <summary>
@@ -188,6 +234,52 @@ public static partial class TranslateTransformExtensions
     public static Avalonia.Media.TranslateTransform OnY(this Avalonia.Media.TranslateTransform obj, Action<Avalonia.Media.TranslateTransform, IObservable<System.Double>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Media.TranslateTransform.YProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.TranslateTransform.YProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingY(this Avalonia.Media.TranslateTransform obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.TranslateTransform.YProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.TranslateTransform.YProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.TranslateTransform OnBindingY(this Avalonia.Media.TranslateTransform obj, Action<Avalonia.Media.TranslateTransform, IObservable<BindingValue<System.Double>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.TranslateTransform.YProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.TranslateTransform.YProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveYChanged(this Avalonia.Media.TranslateTransform obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.TranslateTransform.YProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.TranslateTransform.YProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.TranslateTransform OnYChanged(this Avalonia.Media.TranslateTransform obj, Action<Avalonia.Media.TranslateTransform, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.TranslateTransform.YProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TrayIcon.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TrayIcon.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TrayIconExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Windows.Input.ICommand>> ObserveBindingCommand(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommand<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<BindingValue<System.Windows.Input.ICommand>>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandChanged(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.CommandProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.CommandProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandChanged<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.CommandProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TrayIcon.CommandParameterProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TrayIconExtensions
     public static T OnCommandParameter<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<System.Object>> handler) where T : Avalonia.Controls.TrayIcon
     {
         var observable = obj.GetObservable(Avalonia.Controls.TrayIcon.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingCommandParameter(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCommandParameter<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.CommandParameterProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCommandParameterChanged(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.CommandParameterProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.CommandParameterProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCommandParameterChanged<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.CommandParameterProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TrayIconExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.IconsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.TrayIcons>> ObserveBindingIcons(this Avalonia.Application obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.IconsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.IconsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIcons<T>(this T obj, Action<Avalonia.Application, IObservable<BindingValue<Avalonia.Controls.TrayIcons>>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.IconsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.IconsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIconsChanged(this Avalonia.Application obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.IconsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.IconsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIconsChanged<T>(this T obj, Action<Avalonia.Application, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Application
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.IconsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TrayIcon.MenuProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class TrayIconExtensions
     public static T OnMenu<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<Avalonia.Controls.NativeMenu>> handler) where T : Avalonia.Controls.TrayIcon
     {
         var observable = obj.GetObservable(Avalonia.Controls.TrayIcon.MenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.NativeMenu>> ObserveBindingMenu(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.MenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMenu<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<BindingValue<Avalonia.Controls.NativeMenu>>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.MenuProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMenuChanged(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.MenuProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.MenuProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMenuChanged<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.MenuProperty);
         handler(obj, observable);
         return obj;
     }
@@ -496,6 +688,54 @@ public static partial class TrayIconExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowIcon>> ObserveBindingIcon(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIcon<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<BindingValue<Avalonia.Controls.WindowIcon>>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIconChanged(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIconChanged<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TrayIcon.ToolTipTextProperty
 
     /// <summary>
@@ -594,6 +834,54 @@ public static partial class TrayIconExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.ToolTipTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingToolTipText(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.ToolTipTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.ToolTipTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingToolTipText<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.ToolTipTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.ToolTipTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveToolTipTextChanged(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.ToolTipTextProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.ToolTipTextProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnToolTipTextChanged<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.ToolTipTextProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TrayIcon.IsVisibleProperty
 
     /// <summary>
@@ -688,6 +976,54 @@ public static partial class TrayIconExtensions
     public static T OnIsVisible<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TrayIcon
     {
         var observable = obj.GetObservable(Avalonia.Controls.TrayIcon.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TrayIcon.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsVisible(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TrayIcon.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TrayIcon.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsVisible<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TrayIcon.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TrayIcon.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsVisibleChanged(this Avalonia.Controls.TrayIcon obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TrayIcon.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsVisibleChanged<T>(this T obj, Action<Avalonia.Controls.TrayIcon, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TrayIcon
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TrayIcon.IsVisibleProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGrid.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGrid.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TreeDataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAutoDragDropRows(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAutoDragDropRows<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAutoDragDropRowsChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAutoDragDropRowsChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.AutoDragDropRowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TreeDataGridExtensions
     public static T OnCanUserResizeColumns<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.TreeDataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUserResizeColumns(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanUserResizeColumns<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUserResizeColumnsChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanUserResizeColumnsChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.CanUserResizeColumnsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TreeDataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUserSortColumns(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanUserSortColumns<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUserSortColumnsChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanUserSortColumnsChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.CanUserSortColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeDataGrid.ColumnsProperty
 
     /// <summary>
@@ -340,6 +484,52 @@ public static partial class TreeDataGridExtensions
     public static Avalonia.Controls.TreeDataGrid OnColumns(this Avalonia.Controls.TreeDataGrid obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<Avalonia.Controls.Models.TreeDataGrid.IColumns>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeDataGrid.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IColumns>> ObserveBindingColumns(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TreeDataGrid OnBindingColumns(this Avalonia.Controls.TreeDataGrid obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IColumns>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnsChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TreeDataGrid OnColumnsChanged(this Avalonia.Controls.TreeDataGrid obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ColumnsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -442,6 +632,54 @@ public static partial class TreeDataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.TreeDataGridElementFactory>> ObserveBindingElementFactory(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ElementFactoryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingElementFactory<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<Avalonia.Controls.Primitives.TreeDataGridElementFactory>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ElementFactoryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveElementFactoryChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ElementFactoryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnElementFactoryChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ElementFactoryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeDataGrid.RowsProperty
 
     /// <summary>
@@ -540,6 +778,54 @@ public static partial class TreeDataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IRows>> ObserveBindingRows(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRows<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IRows>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowsChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowsChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeDataGrid.ScrollProperty
 
     /// <summary>
@@ -580,6 +866,52 @@ public static partial class TreeDataGridExtensions
     public static Avalonia.Controls.TreeDataGrid OnScroll(this Avalonia.Controls.TreeDataGrid obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<Avalonia.Controls.Primitives.IScrollable>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeDataGrid.ScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.IScrollable>> ObserveBindingScroll(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TreeDataGrid OnBindingScroll(this Avalonia.Controls.TreeDataGrid obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<Avalonia.Controls.Primitives.IScrollable>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ScrollProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveScrollChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ScrollProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ScrollProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TreeDataGrid OnScrollChanged(this Avalonia.Controls.TreeDataGrid obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ScrollProperty);
         handler(obj, observable);
         return obj;
     }
@@ -682,6 +1014,54 @@ public static partial class TreeDataGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowColumnHeaders(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowColumnHeaders<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowColumnHeadersChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowColumnHeadersChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.ShowColumnHeadersProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeDataGrid.SourceProperty
 
     /// <summary>
@@ -776,6 +1156,54 @@ public static partial class TreeDataGridExtensions
     public static T OnSource<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<Avalonia.Controls.ITreeDataGridSource>> handler) where T : Avalonia.Controls.TreeDataGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeDataGrid.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.ITreeDataGridSource>> ObserveBindingSource(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeDataGrid.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSource<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<BindingValue<Avalonia.Controls.ITreeDataGridSource>>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeDataGrid.SourceProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeDataGrid.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSourceChanged(this Avalonia.Controls.TreeDataGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.SourceProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeDataGrid.SourceProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSourceChanged<T>(this T obj, Action<Avalonia.Controls.TreeDataGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeDataGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeDataGrid.SourceProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGridCell.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridCell.Extensions.g.cs
@@ -49,4 +49,50 @@ public static partial class TreeDataGridCellExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSelected(this Avalonia.Controls.Primitives.TreeDataGridCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridCell OnBindingIsSelected(this Avalonia.Controls.Primitives.TreeDataGridCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridCell, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSelectedChanged(this Avalonia.Controls.Primitives.TreeDataGridCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridCell OnIsSelectedChanged(this Avalonia.Controls.Primitives.TreeDataGridCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCell.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/TreeDataGridCellsPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridCellsPresenter.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class TreeDataGridCellsPresenterExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IRows>> ObserveBindingRows(this Avalonia.Controls.Primitives.TreeDataGridCellsPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRows<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCellsPresenter, IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IRows>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCellsPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowsChanged(this Avalonia.Controls.Primitives.TreeDataGridCellsPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowsChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCellsPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCellsPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCellsPresenter.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/TreeDataGridCheckBoxCell.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridCheckBoxCell.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TreeDataGridCheckBoxCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsReadOnly(this Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsReadOnly<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsReadOnlyChanged(this Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsReadOnlyChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsReadOnlyProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class TreeDataGridCheckBoxCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsThreeState(this Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsThreeState<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsThreeStateChanged(this Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsThreeStateChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.IsThreeStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class TreeDataGridCheckBoxCellExtensions
     public static T OnValue<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<System.Nullable<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.Boolean>>> ObserveBindingValue(this Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingValue<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<BindingValue<System.Nullable<System.Boolean>>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveValueChanged(this Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridCheckBoxCell.ValueProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGridColumnHeader.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridColumnHeader.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class TreeDataGridColumnHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanUserResize(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnBindingCanUserResize(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanUserResizeChanged(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnCanUserResizeChanged(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.CanUserResizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty
 
     /// <summary>
@@ -94,6 +140,52 @@ public static partial class TreeDataGridColumnHeaderExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingHeader(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnBindingHeader(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<BindingValue<System.Object>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHeaderChanged(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnHeaderChanged(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.HeaderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty
 
     /// <summary>
@@ -134,6 +226,52 @@ public static partial class TreeDataGridColumnHeaderExtensions
     public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnSortDirection(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<System.Nullable<System.ComponentModel.ListSortDirection>>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Nullable<System.ComponentModel.ListSortDirection>>> ObserveBindingSortDirection(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnBindingSortDirection(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<BindingValue<System.Nullable<System.ComponentModel.ListSortDirection>>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSortDirectionChanged(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridColumnHeader OnSortDirectionChanged(this Avalonia.Controls.Primitives.TreeDataGridColumnHeader obj, Action<Avalonia.Controls.Primitives.TreeDataGridColumnHeader, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridColumnHeader.SortDirectionProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGridExpanderCell.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridExpanderCell.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class TreeDataGridExpanderCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingIndent(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridExpanderCell OnBindingIndent(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<BindingValue<System.Int32>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIndentChanged(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridExpanderCell OnIndentChanged(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IndentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty
 
     /// <summary>
@@ -148,6 +194,54 @@ public static partial class TreeDataGridExpanderCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsExpanded(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsExpanded<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridExpanderCell
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsExpandedChanged(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsExpandedChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridExpanderCell
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty
 
     /// <summary>
@@ -188,6 +282,52 @@ public static partial class TreeDataGridExpanderCellExtensions
     public static Avalonia.Controls.Primitives.TreeDataGridExpanderCell OnShowExpander(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowExpander(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridExpanderCell OnBindingShowExpander(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowExpanderChanged(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridExpanderCell OnShowExpanderChanged(this Avalonia.Controls.Primitives.TreeDataGridExpanderCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridExpanderCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridExpanderCell.ShowExpanderProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGridRow.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridRow.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class TreeDataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IColumns>> ObserveBindingColumns(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridRow OnBindingColumns(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IColumns>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnsChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridRow OnColumnsChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty
 
     /// <summary>
@@ -148,6 +194,54 @@ public static partial class TreeDataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.TreeDataGridElementFactory>> ObserveBindingElementFactory(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingElementFactory<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<BindingValue<Avalonia.Controls.Primitives.TreeDataGridElementFactory>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridRow
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveElementFactoryChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnElementFactoryChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridRow
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.ElementFactoryProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty
 
     /// <summary>
@@ -192,6 +286,52 @@ public static partial class TreeDataGridRowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsSelected(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridRow OnBindingIsSelected(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsSelectedChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridRow OnIsSelectedChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.IsSelectedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty
 
     /// <summary>
@@ -232,6 +372,52 @@ public static partial class TreeDataGridRowExtensions
     public static Avalonia.Controls.Primitives.TreeDataGridRow OnRows(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<Avalonia.Controls.Models.TreeDataGrid.IRows>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IRows>> ObserveBindingRows(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridRow OnBindingRows(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IRows>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowsChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridRow OnRowsChanged(this Avalonia.Controls.Primitives.TreeDataGridRow obj, Action<Avalonia.Controls.Primitives.TreeDataGridRow, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRow.RowsProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGridRowsPresenter.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridRowsPresenter.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class TreeDataGridRowsPresenterExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IColumns>> ObserveBindingColumns(this Avalonia.Controls.Primitives.TreeDataGridRowsPresenter obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumns<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridRowsPresenter, IObservable<BindingValue<Avalonia.Controls.Models.TreeDataGrid.IColumns>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridRowsPresenter
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnsChanged(this Avalonia.Controls.Primitives.TreeDataGridRowsPresenter obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnsChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridRowsPresenter, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridRowsPresenter
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridRowsPresenter.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/TreeDataGridTemplateCell.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridTemplateCell.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class TreeDataGridTemplateCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingContent(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnBindingContent(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<BindingValue<System.Object>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentChanged(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnContentChanged(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty
 
     /// <summary>
@@ -94,6 +140,52 @@ public static partial class TreeDataGridTemplateCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingContentTemplate(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnBindingContentTemplate(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveContentTemplateChanged(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnContentTemplateChanged(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.ContentTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty
 
     /// <summary>
@@ -134,6 +226,52 @@ public static partial class TreeDataGridTemplateCellExtensions
     public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnEditingTemplate(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<Avalonia.Controls.Templates.IDataTemplate>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>> ObserveBindingEditingTemplate(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnBindingEditingTemplate(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<BindingValue<Avalonia.Controls.Templates.IDataTemplate>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEditingTemplateChanged(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTemplateCell OnEditingTemplateChanged(this Avalonia.Controls.Primitives.TreeDataGridTemplateCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTemplateCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTemplateCell.EditingTemplateProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeDataGridTextCell.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeDataGridTextCell.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class TreeDataGridTextCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextTrimming>> ObserveBindingTextTrimming(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTextCell OnBindingTextTrimming(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<BindingValue<Avalonia.Media.TextTrimming>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextTrimmingChanged(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTextCell OnTextTrimmingChanged(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextTrimmingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty
 
     /// <summary>
@@ -90,6 +136,52 @@ public static partial class TreeDataGridTextCellExtensions
     public static Avalonia.Controls.Primitives.TreeDataGridTextCell OnTextWrapping(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<Avalonia.Media.TextWrapping>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextWrapping>> ObserveBindingTextWrapping(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTextCell OnBindingTextWrapping(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<BindingValue<Avalonia.Media.TextWrapping>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextWrappingChanged(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Primitives.TreeDataGridTextCell OnTextWrappingChanged(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextWrappingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -192,6 +284,54 @@ public static partial class TreeDataGridTextCellExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingValue(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingValue<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridTextCell
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveValueChanged(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnValueChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridTextCell
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.ValueProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty
 
     /// <summary>
@@ -286,6 +426,54 @@ public static partial class TreeDataGridTextCellExtensions
     public static T OnTextAlignment<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<Avalonia.Media.TextAlignment>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridTextCell
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.TextAlignment>> ObserveBindingTextAlignment(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTextAlignment<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<BindingValue<Avalonia.Media.TextAlignment>>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridTextCell
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTextAlignmentChanged(this Avalonia.Controls.Primitives.TreeDataGridTextCell obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTextAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.TreeDataGridTextCell, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.TreeDataGridTextCell
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.TreeDataGridTextCell.TextAlignmentProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeView.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeView.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TreeViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAutoScrollToSelectedItem(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAutoScrollToSelectedItem<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAutoScrollToSelectedItemChanged(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAutoScrollToSelectedItemChanged<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.AutoScrollToSelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeView.SelectedItemProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class TreeViewExtensions
     public static T OnSelectedItem<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<System.Object>> handler) where T : Avalonia.Controls.TreeView
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeView.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeView.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Object>> ObserveBindingSelectedItem(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeView.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeView.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedItem<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<BindingValue<System.Object>>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeView.SelectedItemProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeView.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedItemChanged(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.SelectedItemProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeView.SelectedItemProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedItemChanged<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.SelectedItemProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class TreeViewExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeView.SelectedItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Collections.IList>> ObserveBindingSelectedItems(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeView.SelectedItemsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeView.SelectedItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectedItems<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<BindingValue<System.Collections.IList>>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeView.SelectedItemsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeView.SelectedItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectedItemsChanged(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.SelectedItemsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeView.SelectedItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectedItemsChanged<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.SelectedItemsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeView.SelectionModeProperty
 
     /// <summary>
@@ -394,6 +538,54 @@ public static partial class TreeViewExtensions
     public static T OnSelectionMode<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<Avalonia.Controls.SelectionMode>> handler) where T : Avalonia.Controls.TreeView
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeView.SelectionModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeView.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.SelectionMode>> ObserveBindingSelectionMode(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeView.SelectionModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeView.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSelectionMode<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<BindingValue<Avalonia.Controls.SelectionMode>>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeView.SelectionModeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeView.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSelectionModeChanged(this Avalonia.Controls.TreeView obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.SelectionModeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeView.SelectionModeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSelectionModeChanged<T>(this T obj, Action<Avalonia.Controls.TreeView, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeView
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeView.SelectionModeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/TreeViewItem.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/TreeViewItem.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class TreeViewItemExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeViewItem.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsExpanded(this Avalonia.Controls.TreeViewItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeViewItem.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeViewItem.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsExpanded<T>(this T obj, Action<Avalonia.Controls.TreeViewItem, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.TreeViewItem
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeViewItem.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeViewItem.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsExpandedChanged(this Avalonia.Controls.TreeViewItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeViewItem.IsExpandedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeViewItem.IsExpandedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsExpandedChanged<T>(this T obj, Action<Avalonia.Controls.TreeViewItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.TreeViewItem
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeViewItem.IsExpandedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.TreeViewItem.LevelProperty
 
     /// <summary>
@@ -144,6 +192,52 @@ public static partial class TreeViewItemExtensions
     public static Avalonia.Controls.TreeViewItem OnLevel(this Avalonia.Controls.TreeViewItem obj, Action<Avalonia.Controls.TreeViewItem, IObservable<System.Int32>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.TreeViewItem.LevelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.TreeViewItem.LevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingLevel(this Avalonia.Controls.TreeViewItem obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.TreeViewItem.LevelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.TreeViewItem.LevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TreeViewItem OnBindingLevel(this Avalonia.Controls.TreeViewItem obj, Action<Avalonia.Controls.TreeViewItem, IObservable<BindingValue<System.Int32>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.TreeViewItem.LevelProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.TreeViewItem.LevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLevelChanged(this Avalonia.Controls.TreeViewItem obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.TreeViewItem.LevelProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.TreeViewItem.LevelProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.TreeViewItem OnLevelChanged(this Avalonia.Controls.TreeViewItem obj, Action<Avalonia.Controls.TreeViewItem, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.TreeViewItem.LevelProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/UniformGrid.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/UniformGrid.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class UniformGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingRows(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRows<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowsChanged(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.RowsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowsChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.RowsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty
 
     /// <summary>
@@ -198,6 +246,54 @@ public static partial class UniformGridExtensions
     public static T OnColumns<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingColumns(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumns<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnsChanged(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnsChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -300,6 +396,54 @@ public static partial class UniformGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingFirstColumn(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFirstColumn<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFirstColumnChanged(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFirstColumnChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.FirstColumnProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty
 
     /// <summary>
@@ -398,6 +542,54 @@ public static partial class UniformGridExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingRowSpacing(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRowSpacing<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRowSpacingChanged(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRowSpacingChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.RowSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty
 
     /// <summary>
@@ -492,6 +684,54 @@ public static partial class UniformGridExtensions
     public static T OnColumnSpacing<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<System.Double>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
     {
         var observable = obj.GetObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingColumnSpacing(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingColumnSpacing<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveColumnSpacingChanged(this Avalonia.Controls.Primitives.UniformGrid obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnColumnSpacingChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.UniformGrid, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.UniformGrid
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.UniformGrid.ColumnSpacingProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/UniformGridLayout.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/UniformGridLayout.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class UniformGridLayoutExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.UniformGridLayoutItemsJustification>> ObserveBindingItemsJustification(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsJustification<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<Avalonia.Layout.UniformGridLayoutItemsJustification>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsJustificationChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsJustificationChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Layout.UniformGridLayout.ItemsJustificationProperty"/> property value to <see cref="Avalonia.Layout.UniformGridLayoutItemsJustification.Start"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -275,6 +323,54 @@ public static partial class UniformGridLayoutExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.UniformGridLayoutItemsStretch>> ObserveBindingItemsStretch(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.ItemsStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsStretch<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<Avalonia.Layout.UniformGridLayoutItemsStretch>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.ItemsStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsStretchChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.ItemsStretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.ItemsStretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsStretchChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.ItemsStretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Layout.UniformGridLayout.ItemsStretchProperty"/> property value to <see cref="Avalonia.Layout.UniformGridLayoutItemsStretch.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -408,6 +504,54 @@ public static partial class UniformGridLayoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinColumnSpacing(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinColumnSpacing<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinColumnSpacingChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinColumnSpacingChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinColumnSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.UniformGridLayout.MinItemHeightProperty
 
     /// <summary>
@@ -502,6 +646,54 @@ public static partial class UniformGridLayoutExtensions
     public static T OnMinItemHeight<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<System.Double>> handler) where T : Avalonia.Layout.UniformGridLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.UniformGridLayout.MinItemHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinItemHeight(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinItemHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinItemHeight<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinItemHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinItemHeightChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinItemHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinItemHeightChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinItemHeightProperty);
         handler(obj, observable);
         return obj;
     }
@@ -604,6 +796,54 @@ public static partial class UniformGridLayoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinItemWidth(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinItemWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinItemWidth<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinItemWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinItemWidthChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinItemWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinItemWidthChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinItemWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty
 
     /// <summary>
@@ -698,6 +938,54 @@ public static partial class UniformGridLayoutExtensions
     public static T OnMinRowSpacing<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<System.Double>> handler) where T : Avalonia.Layout.UniformGridLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingMinRowSpacing(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMinRowSpacing<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMinRowSpacingChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMinRowSpacingChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MinRowSpacingProperty);
         handler(obj, observable);
         return obj;
     }
@@ -800,6 +1088,54 @@ public static partial class UniformGridLayoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaximumRowsOrColumns(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaximumRowsOrColumns<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaximumRowsOrColumnsChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaximumRowsOrColumnsChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.MaximumRowsOrColumnsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.UniformGridLayout.OrientationProperty
 
     /// <summary>
@@ -894,6 +1230,54 @@ public static partial class UniformGridLayoutExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Layout.UniformGridLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.UniformGridLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.UniformGridLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.UniformGridLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.UniformGridLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Layout.UniformGridLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.UniformGridLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Layout.UniformGridLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.UniformGridLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.UniformGridLayout.OrientationProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Viewbox.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Viewbox.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class ViewboxExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Viewbox.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Stretch>> ObserveBindingStretch(this Avalonia.Controls.Viewbox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Viewbox.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Viewbox.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStretch<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<BindingValue<Avalonia.Media.Stretch>>> handler) where T : Avalonia.Controls.Viewbox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Viewbox.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Viewbox.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStretchChanged(this Avalonia.Controls.Viewbox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Viewbox.StretchProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Viewbox.StretchProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStretchChanged<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Viewbox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Viewbox.StretchProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Viewbox.StretchProperty"/> property value to <see cref="Avalonia.Media.Stretch.None"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -251,6 +299,54 @@ public static partial class ViewboxExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Viewbox.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.StretchDirection>> ObserveBindingStretchDirection(this Avalonia.Controls.Viewbox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Viewbox.StretchDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Viewbox.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingStretchDirection<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<BindingValue<Avalonia.Media.StretchDirection>>> handler) where T : Avalonia.Controls.Viewbox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Viewbox.StretchDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Viewbox.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveStretchDirectionChanged(this Avalonia.Controls.Viewbox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Viewbox.StretchDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Viewbox.StretchDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnStretchDirectionChanged<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Viewbox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Viewbox.StretchDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Viewbox.StretchDirectionProperty"/> property value to <see cref="Avalonia.Media.StretchDirection.UpOnly"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -380,6 +476,54 @@ public static partial class ViewboxExtensions
     public static T OnChild<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<Avalonia.Controls.Control>> handler) where T : Avalonia.Controls.Viewbox
     {
         var observable = obj.GetObservable(Avalonia.Controls.Viewbox.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Viewbox.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Control>> ObserveBindingChild(this Avalonia.Controls.Viewbox obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Viewbox.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Viewbox.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingChild<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<BindingValue<Avalonia.Controls.Control>>> handler) where T : Avalonia.Controls.Viewbox
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Viewbox.ChildProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Viewbox.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChildChanged(this Avalonia.Controls.Viewbox obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Viewbox.ChildProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Viewbox.ChildProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnChildChanged<T>(this T obj, Action<Avalonia.Controls.Viewbox, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Viewbox
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Viewbox.ChildProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/VirtualizingStackPanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/VirtualizingStackPanel.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class VirtualizingStackPanelExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.VirtualizingStackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.VirtualizingStackPanel.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.VirtualizingStackPanel.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.VirtualizingStackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.VirtualizingStackPanel.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.VirtualizingStackPanel.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.VirtualizingStackPanel.OrientationProperty"/> property value to <see cref="Avalonia.Layout.Orientation.Horizontal"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -226,6 +274,54 @@ public static partial class VirtualizingStackPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreHorizontalSnapPointsRegular(this Avalonia.Controls.VirtualizingStackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreHorizontalSnapPointsRegular<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreHorizontalSnapPointsRegularChanged(this Avalonia.Controls.VirtualizingStackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreHorizontalSnapPointsRegularChanged<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.VirtualizingStackPanel.AreHorizontalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty
 
     /// <summary>
@@ -320,6 +416,54 @@ public static partial class VirtualizingStackPanelExtensions
     public static T OnAreVerticalSnapPointsRegular<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingAreVerticalSnapPointsRegular(this Avalonia.Controls.VirtualizingStackPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingAreVerticalSnapPointsRegular<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveAreVerticalSnapPointsRegularChanged(this Avalonia.Controls.VirtualizingStackPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnAreVerticalSnapPointsRegularChanged<T>(this T obj, Action<Avalonia.Controls.VirtualizingStackPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.VirtualizingStackPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.VirtualizingStackPanel.AreVerticalSnapPointsRegularProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/Visual.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Visual.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class VisualExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.BoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Rect>> ObserveBindingBounds(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.BoundsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.BoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Visual OnBindingBounds(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Rect>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.BoundsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.BoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveBoundsChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.BoundsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.BoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Visual OnBoundsChanged(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.BoundsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Visual.ClipToBoundsProperty
 
     /// <summary>
@@ -144,6 +190,54 @@ public static partial class VisualExtensions
     public static T OnClipToBounds<T>(this T obj, Action<Avalonia.Visual, IObservable<System.Boolean>> handler) where T : Avalonia.Visual
     {
         var observable = obj.GetObservable(Avalonia.Visual.ClipToBoundsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.ClipToBoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingClipToBounds(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.ClipToBoundsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.ClipToBoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClipToBounds<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.ClipToBoundsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.ClipToBoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClipToBoundsChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.ClipToBoundsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.ClipToBoundsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClipToBoundsChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.ClipToBoundsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -246,6 +340,54 @@ public static partial class VisualExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.ClipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.Geometry>> ObserveBindingClip(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.ClipProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.ClipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClip<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Media.Geometry>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.ClipProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.ClipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClipChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.ClipProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.ClipProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClipChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.ClipProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Visual.IsVisibleProperty
 
     /// <summary>
@@ -340,6 +482,54 @@ public static partial class VisualExtensions
     public static T OnIsVisible<T>(this T obj, Action<Avalonia.Visual, IObservable<System.Boolean>> handler) where T : Avalonia.Visual
     {
         var observable = obj.GetObservable(Avalonia.Visual.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsVisible(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIsVisible<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.IsVisibleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsVisibleChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.IsVisibleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.IsVisibleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIsVisibleChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.IsVisibleProperty);
         handler(obj, observable);
         return obj;
     }
@@ -442,6 +632,54 @@ public static partial class VisualExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingOpacity(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOpacity<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpacityChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.OpacityProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.OpacityProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOpacityChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.OpacityProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Visual.OpacityMaskProperty
 
     /// <summary>
@@ -536,6 +774,54 @@ public static partial class VisualExtensions
     public static T OnOpacityMask<T>(this T obj, Action<Avalonia.Visual, IObservable<Avalonia.Media.IBrush>> handler) where T : Avalonia.Visual
     {
         var observable = obj.GetObservable(Avalonia.Visual.OpacityMaskProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IBrush>> ObserveBindingOpacityMask(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.OpacityMaskProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOpacityMask<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Media.IBrush>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.OpacityMaskProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOpacityMaskChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.OpacityMaskProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.OpacityMaskProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOpacityMaskChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.OpacityMaskProperty);
         handler(obj, observable);
         return obj;
     }
@@ -638,6 +924,54 @@ public static partial class VisualExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.EffectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.IEffect>> ObserveBindingEffect(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.EffectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.EffectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingEffect<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Media.IEffect>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.EffectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.EffectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveEffectChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.EffectProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.EffectProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnEffectChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.EffectProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Visual.HasMirrorTransformProperty
 
     /// <summary>
@@ -678,6 +1012,52 @@ public static partial class VisualExtensions
     public static Avalonia.Visual OnHasMirrorTransform(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Visual.HasMirrorTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.HasMirrorTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingHasMirrorTransform(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.HasMirrorTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.HasMirrorTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Visual OnBindingHasMirrorTransform(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.HasMirrorTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.HasMirrorTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHasMirrorTransformChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.HasMirrorTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.HasMirrorTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Visual OnHasMirrorTransformChanged(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.HasMirrorTransformProperty);
         handler(obj, observable);
         return obj;
     }
@@ -780,6 +1160,54 @@ public static partial class VisualExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.RenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.ITransform>> ObserveBindingRenderTransform(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.RenderTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.RenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRenderTransform<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Media.ITransform>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.RenderTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.RenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRenderTransformChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.RenderTransformProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.RenderTransformProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRenderTransformChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.RenderTransformProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Visual.RenderTransformOriginProperty
 
     /// <summary>
@@ -874,6 +1302,54 @@ public static partial class VisualExtensions
     public static T OnRenderTransformOrigin<T>(this T obj, Action<Avalonia.Visual, IObservable<Avalonia.RelativePoint>> handler) where T : Avalonia.Visual
     {
         var observable = obj.GetObservable(Avalonia.Visual.RenderTransformOriginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.RenderTransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.RelativePoint>> ObserveBindingRenderTransformOrigin(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.RenderTransformOriginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.RenderTransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingRenderTransformOrigin<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.RelativePoint>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.RenderTransformOriginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.RenderTransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveRenderTransformOriginChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.RenderTransformOriginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.RenderTransformOriginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnRenderTransformOriginChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.RenderTransformOriginProperty);
         handler(obj, observable);
         return obj;
     }
@@ -977,6 +1453,54 @@ public static partial class VisualExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.FlowDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Media.FlowDirection>> ObserveBindingFlowDirection(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.FlowDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.FlowDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingFlowDirection<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Media.FlowDirection>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.FlowDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.FlowDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveFlowDirectionChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.FlowDirectionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.FlowDirectionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnFlowDirectionChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.FlowDirectionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Visual.FlowDirectionProperty"/> property value to <see cref="Avalonia.Media.FlowDirection.LeftToRight"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -1040,6 +1564,52 @@ public static partial class VisualExtensions
     public static Avalonia.Visual OnVisualParent(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<Avalonia.Visual>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Visual.VisualParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.VisualParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Visual>> ObserveBindingVisualParent(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.VisualParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.VisualParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Visual OnBindingVisualParent(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<BindingValue<Avalonia.Visual>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.VisualParentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.VisualParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVisualParentChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.VisualParentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.VisualParentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Visual OnVisualParentChanged(this Avalonia.Visual obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.VisualParentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1138,6 +1708,54 @@ public static partial class VisualExtensions
     public static T OnZIndex<T>(this T obj, Action<Avalonia.Visual, IObservable<System.Int32>> handler) where T : Avalonia.Visual
     {
         var observable = obj.GetObservable(Avalonia.Visual.ZIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Visual.ZIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingZIndex(this Avalonia.Visual obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Visual.ZIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Visual.ZIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingZIndex<T>(this T obj, Action<Avalonia.Visual, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Visual.ZIndexProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Visual.ZIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveZIndexChanged(this Avalonia.Visual obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Visual.ZIndexProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Visual.ZIndexProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnZIndexChanged<T>(this T obj, Action<Avalonia.Visual, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Visual
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Visual.ZIndexProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/VisualBrush.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/VisualBrush.Extensions.g.cs
@@ -98,4 +98,50 @@ public static partial class VisualBrushExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Media.VisualBrush.VisualProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Visual>> ObserveBindingVisual(this Avalonia.Media.VisualBrush obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Media.VisualBrush.VisualProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Media.VisualBrush.VisualProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.VisualBrush OnBindingVisual(this Avalonia.Media.VisualBrush obj, Action<Avalonia.Media.VisualBrush, IObservable<BindingValue<Avalonia.Visual>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Media.VisualBrush.VisualProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Media.VisualBrush.VisualProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVisualChanged(this Avalonia.Media.VisualBrush obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Media.VisualBrush.VisualProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Media.VisualBrush.VisualProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object.</returns>
+    public static Avalonia.Media.VisualBrush OnVisualChanged(this Avalonia.Media.VisualBrush obj, Action<Avalonia.Media.VisualBrush, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Media.VisualBrush.VisualProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/VisualLayerManager.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/VisualLayerManager.Extensions.g.cs
@@ -103,4 +103,52 @@ public static partial class VisualLayerManagerExtensions
         handler(obj, observable);
         return obj;
     }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Primitives.ChromeOverlayLayer>> ObserveBindingChromeOverlayLayer(this Avalonia.Controls.Primitives.VisualLayerManager obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingChromeOverlayLayer<T>(this T obj, Action<Avalonia.Controls.Primitives.VisualLayerManager, IObservable<BindingValue<Avalonia.Controls.Primitives.ChromeOverlayLayer>>> handler) where T : Avalonia.Controls.Primitives.VisualLayerManager
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveChromeOverlayLayerChanged(this Avalonia.Controls.Primitives.VisualLayerManager obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnChromeOverlayLayerChanged<T>(this T obj, Action<Avalonia.Controls.Primitives.VisualLayerManager, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Primitives.VisualLayerManager
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Primitives.VisualLayerManager.ChromeOverlayLayerProperty);
+        handler(obj, observable);
+        return obj;
+    }
 }

--- a/src/NXUI/Generated/Extensions/Window.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/Window.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class WindowExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.SizeToContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.SizeToContent>> ObserveBindingSizeToContent(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.SizeToContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.SizeToContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSizeToContent<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Controls.SizeToContent>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.SizeToContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.SizeToContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSizeToContentChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.SizeToContentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.SizeToContentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSizeToContentChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.SizeToContentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Window.SizeToContentProperty"/> property value to <see cref="Avalonia.Controls.SizeToContent.Manual"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -250,6 +298,54 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingExtendClientAreaToDecorationsHint(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingExtendClientAreaToDecorationsHint<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveExtendClientAreaToDecorationsHintChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnExtendClientAreaToDecorationsHintChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ExtendClientAreaToDecorationsHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty
 
     /// <summary>
@@ -344,6 +440,54 @@ public static partial class WindowExtensions
     public static T OnExtendClientAreaChromeHints<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<Avalonia.Platform.ExtendClientAreaChromeHints>> handler) where T : Avalonia.Controls.Window
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Platform.ExtendClientAreaChromeHints>> ObserveBindingExtendClientAreaChromeHints(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingExtendClientAreaChromeHints<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Platform.ExtendClientAreaChromeHints>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveExtendClientAreaChromeHintsChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnExtendClientAreaChromeHintsChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ExtendClientAreaChromeHintsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -506,6 +650,54 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingExtendClientAreaTitleBarHeightHint(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingExtendClientAreaTitleBarHeightHint<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveExtendClientAreaTitleBarHeightHintChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnExtendClientAreaTitleBarHeightHintChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ExtendClientAreaTitleBarHeightHintProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty
 
     /// <summary>
@@ -546,6 +738,52 @@ public static partial class WindowExtensions
     public static Avalonia.Controls.Window OnIsExtendedIntoWindowDecorations(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<System.Boolean>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsExtendedIntoWindowDecorations(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Window OnBindingIsExtendedIntoWindowDecorations(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsExtendedIntoWindowDecorationsChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Window OnIsExtendedIntoWindowDecorationsChanged(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.IsExtendedIntoWindowDecorationsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -594,6 +832,52 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.WindowDecorationMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingWindowDecorationMargin(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.WindowDecorationMarginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.WindowDecorationMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Window OnBindingWindowDecorationMargin(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Thickness>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.WindowDecorationMarginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.WindowDecorationMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWindowDecorationMarginChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.WindowDecorationMarginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.WindowDecorationMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Window OnWindowDecorationMarginChanged(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.WindowDecorationMarginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.OffScreenMarginProperty
 
     /// <summary>
@@ -634,6 +918,52 @@ public static partial class WindowExtensions
     public static Avalonia.Controls.Window OnOffScreenMargin(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<Avalonia.Thickness>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.OffScreenMarginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.OffScreenMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Thickness>> ObserveBindingOffScreenMargin(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.OffScreenMarginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.OffScreenMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Window OnBindingOffScreenMargin(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Thickness>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.OffScreenMarginProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.OffScreenMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOffScreenMarginChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.OffScreenMarginProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.OffScreenMarginProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.Window OnOffScreenMarginChanged(this Avalonia.Controls.Window obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.OffScreenMarginProperty);
         handler(obj, observable);
         return obj;
     }
@@ -732,6 +1062,54 @@ public static partial class WindowExtensions
     public static T OnSystemDecorations<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<Avalonia.Controls.SystemDecorations>> handler) where T : Avalonia.Controls.Window
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.SystemDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.SystemDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.SystemDecorations>> ObserveBindingSystemDecorations(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.SystemDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.SystemDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingSystemDecorations<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Controls.SystemDecorations>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.SystemDecorationsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.SystemDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveSystemDecorationsChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.SystemDecorationsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.SystemDecorationsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnSystemDecorationsChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.SystemDecorationsProperty);
         handler(obj, observable);
         return obj;
     }
@@ -870,6 +1248,54 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.ShowActivatedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowActivated(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.ShowActivatedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.ShowActivatedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowActivated<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.ShowActivatedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.ShowActivatedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowActivatedChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ShowActivatedProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.ShowActivatedProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowActivatedChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ShowActivatedProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.ShowInTaskbarProperty
 
     /// <summary>
@@ -968,6 +1394,54 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.ShowInTaskbarProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingShowInTaskbar(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.ShowInTaskbarProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.ShowInTaskbarProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingShowInTaskbar<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.ShowInTaskbarProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.ShowInTaskbarProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveShowInTaskbarChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ShowInTaskbarProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.ShowInTaskbarProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnShowInTaskbarChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ShowInTaskbarProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.ClosingBehaviorProperty
 
     /// <summary>
@@ -1062,6 +1536,54 @@ public static partial class WindowExtensions
     public static T OnClosingBehavior<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<Avalonia.Controls.WindowClosingBehavior>> handler) where T : Avalonia.Controls.Window
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.ClosingBehaviorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.ClosingBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowClosingBehavior>> ObserveBindingClosingBehavior(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.ClosingBehaviorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.ClosingBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingClosingBehavior<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Controls.WindowClosingBehavior>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.ClosingBehaviorProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.ClosingBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveClosingBehaviorChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ClosingBehaviorProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.ClosingBehaviorProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnClosingBehaviorChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.ClosingBehaviorProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1184,6 +1706,54 @@ public static partial class WindowExtensions
     public static T OnWindowState<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<Avalonia.Controls.WindowState>> handler) where T : Avalonia.Controls.Window
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.WindowStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.WindowStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowState>> ObserveBindingWindowState(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.WindowStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.WindowStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWindowState<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Controls.WindowState>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.WindowStateProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.WindowStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWindowStateChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.WindowStateProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.WindowStateProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWindowStateChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.WindowStateProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1334,6 +1904,54 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.TitleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.String>> ObserveBindingTitle(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.TitleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.TitleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTitle<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.String>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.TitleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.TitleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTitleChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.TitleProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.TitleProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTitleChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.TitleProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.IconProperty
 
     /// <summary>
@@ -1432,6 +2050,54 @@ public static partial class WindowExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowIcon>> ObserveBindingIcon(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingIcon<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Controls.WindowIcon>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIconChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.IconProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.IconProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnIconChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.IconProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.Window.WindowStartupLocationProperty
 
     /// <summary>
@@ -1526,6 +2192,54 @@ public static partial class WindowExtensions
     public static T OnWindowStartupLocation<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<Avalonia.Controls.WindowStartupLocation>> handler) where T : Avalonia.Controls.Window
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.WindowStartupLocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.WindowStartupLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowStartupLocation>> ObserveBindingWindowStartupLocation(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.WindowStartupLocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.WindowStartupLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingWindowStartupLocation<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<Avalonia.Controls.WindowStartupLocation>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.WindowStartupLocationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.WindowStartupLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveWindowStartupLocationChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.WindowStartupLocationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.WindowStartupLocationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnWindowStartupLocationChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.WindowStartupLocationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -1660,6 +2374,54 @@ public static partial class WindowExtensions
     public static T OnCanResize<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.Window
     {
         var observable = obj.GetObservable(Avalonia.Controls.Window.CanResizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Window.CanResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingCanResize(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Window.CanResizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Window.CanResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingCanResize<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Window.CanResizeProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Window.CanResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveCanResizeChanged(this Avalonia.Controls.Window obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Window.CanResizeProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Window.CanResizeProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnCanResizeChanged<T>(this T obj, Action<Avalonia.Controls.Window, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Window
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Window.CanResizeProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/WindowBase.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/WindowBase.Extensions.g.cs
@@ -50,6 +50,52 @@ public static partial class WindowBaseExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WindowBase.IsActiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingIsActive(this Avalonia.Controls.WindowBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WindowBase.IsActiveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WindowBase.IsActiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.WindowBase OnBindingIsActive(this Avalonia.Controls.WindowBase obj, Action<Avalonia.Controls.WindowBase, IObservable<BindingValue<System.Boolean>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WindowBase.IsActiveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WindowBase.IsActiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveIsActiveChanged(this Avalonia.Controls.WindowBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WindowBase.IsActiveProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WindowBase.IsActiveProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.WindowBase OnIsActiveChanged(this Avalonia.Controls.WindowBase obj, Action<Avalonia.Controls.WindowBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WindowBase.IsActiveProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.WindowBase.OwnerProperty
 
     /// <summary>
@@ -90,6 +136,52 @@ public static partial class WindowBaseExtensions
     public static Avalonia.Controls.WindowBase OnOwner(this Avalonia.Controls.WindowBase obj, Action<Avalonia.Controls.WindowBase, IObservable<Avalonia.Controls.WindowBase>> handler)
     {
         var observable = obj.GetObservable(Avalonia.Controls.WindowBase.OwnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WindowBase.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WindowBase>> ObserveBindingOwner(this Avalonia.Controls.WindowBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WindowBase.OwnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WindowBase.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.WindowBase OnBindingOwner(this Avalonia.Controls.WindowBase obj, Action<Avalonia.Controls.WindowBase, IObservable<BindingValue<Avalonia.Controls.WindowBase>>> handler)
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WindowBase.OwnerProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WindowBase.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOwnerChanged(this Avalonia.Controls.WindowBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WindowBase.OwnerProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WindowBase.OwnerProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <returns>The target object reference.</returns>
+    public static Avalonia.Controls.WindowBase OnOwnerChanged(this Avalonia.Controls.WindowBase obj, Action<Avalonia.Controls.WindowBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler)
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WindowBase.OwnerProperty);
         handler(obj, observable);
         return obj;
     }
@@ -188,6 +280,54 @@ public static partial class WindowBaseExtensions
     public static T OnTopmost<T>(this T obj, Action<Avalonia.Controls.WindowBase, IObservable<System.Boolean>> handler) where T : Avalonia.Controls.WindowBase
     {
         var observable = obj.GetObservable(Avalonia.Controls.WindowBase.TopmostProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WindowBase.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Boolean>> ObserveBindingTopmost(this Avalonia.Controls.WindowBase obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WindowBase.TopmostProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WindowBase.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingTopmost<T>(this T obj, Action<Avalonia.Controls.WindowBase, IObservable<BindingValue<System.Boolean>>> handler) where T : Avalonia.Controls.WindowBase
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WindowBase.TopmostProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WindowBase.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveTopmostChanged(this Avalonia.Controls.WindowBase obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WindowBase.TopmostProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WindowBase.TopmostProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnTopmostChanged<T>(this T obj, Action<Avalonia.Controls.WindowBase, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WindowBase
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WindowBase.TopmostProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/WindowNotificationManager.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/WindowNotificationManager.Extensions.g.cs
@@ -105,6 +105,54 @@ public static partial class WindowNotificationManagerExtensions
     }
 
     /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.Notifications.NotificationPosition>> ObserveBindingPosition(this Avalonia.Controls.Notifications.WindowNotificationManager obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingPosition<T>(this T obj, Action<Avalonia.Controls.Notifications.WindowNotificationManager, IObservable<BindingValue<Avalonia.Controls.Notifications.NotificationPosition>>> handler) where T : Avalonia.Controls.Notifications.WindowNotificationManager
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObservePositionChanged(this Avalonia.Controls.Notifications.WindowNotificationManager obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnPositionChanged<T>(this T obj, Action<Avalonia.Controls.Notifications.WindowNotificationManager, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Notifications.WindowNotificationManager
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
     /// Sets a <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.PositionProperty"/> property value to <see cref="Avalonia.Controls.Notifications.NotificationPosition.TopLeft"/>.
     /// </summary>
     /// <param name="obj">The target object.</param>
@@ -270,6 +318,54 @@ public static partial class WindowNotificationManagerExtensions
     public static T OnMaxItems<T>(this T obj, Action<Avalonia.Controls.Notifications.WindowNotificationManager, IObservable<System.Int32>> handler) where T : Avalonia.Controls.Notifications.WindowNotificationManager
     {
         var observable = obj.GetObservable(Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Int32>> ObserveBindingMaxItems(this Avalonia.Controls.Notifications.WindowNotificationManager obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingMaxItems<T>(this T obj, Action<Avalonia.Controls.Notifications.WindowNotificationManager, IObservable<BindingValue<System.Int32>>> handler) where T : Avalonia.Controls.Notifications.WindowNotificationManager
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveMaxItemsChanged(this Avalonia.Controls.Notifications.WindowNotificationManager obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnMaxItemsChanged<T>(this T obj, Action<Avalonia.Controls.Notifications.WindowNotificationManager, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.Notifications.WindowNotificationManager
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.Notifications.WindowNotificationManager.MaxItemsProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/WrapLayout.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/WrapLayout.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class WrapLayoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.WrapLayout.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingHorizontalSpacing(this Avalonia.Layout.WrapLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.WrapLayout.HorizontalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.WrapLayout.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingHorizontalSpacing<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.WrapLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.WrapLayout.HorizontalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.WrapLayout.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveHorizontalSpacingChanged(this Avalonia.Layout.WrapLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.WrapLayout.HorizontalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.WrapLayout.HorizontalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnHorizontalSpacingChanged<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.WrapLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.WrapLayout.HorizontalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.WrapLayout.VerticalSpacingProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class WrapLayoutExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.WrapLayout.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingVerticalSpacing(this Avalonia.Layout.WrapLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.WrapLayout.VerticalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.WrapLayout.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingVerticalSpacing<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Layout.WrapLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.WrapLayout.VerticalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.WrapLayout.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveVerticalSpacingChanged(this Avalonia.Layout.WrapLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.WrapLayout.VerticalSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.WrapLayout.VerticalSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnVerticalSpacingChanged<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.WrapLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.WrapLayout.VerticalSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Layout.WrapLayout.OrientationProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class WrapLayoutExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Layout.WrapLayout
     {
         var observable = obj.GetObservable(Avalonia.Layout.WrapLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Layout.WrapLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Layout.WrapLayout obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Layout.WrapLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Layout.WrapLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Layout.WrapLayout
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Layout.WrapLayout.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Layout.WrapLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Layout.WrapLayout obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Layout.WrapLayout.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Layout.WrapLayout.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Layout.WrapLayout, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Layout.WrapLayout
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Layout.WrapLayout.OrientationProperty);
         handler(obj, observable);
         return obj;
     }

--- a/src/NXUI/Generated/Extensions/WrapPanel.Extensions.g.cs
+++ b/src/NXUI/Generated/Extensions/WrapPanel.Extensions.g.cs
@@ -104,6 +104,54 @@ public static partial class WrapPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingItemSpacing(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemSpacing<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemSpacingChanged(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemSpacingChanged<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.WrapPanel.LineSpacingProperty
 
     /// <summary>
@@ -202,6 +250,54 @@ public static partial class WrapPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WrapPanel.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingLineSpacing(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WrapPanel.LineSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WrapPanel.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingLineSpacing<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WrapPanel.LineSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WrapPanel.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveLineSpacingChanged(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.LineSpacingProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WrapPanel.LineSpacingProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnLineSpacingChanged<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.LineSpacingProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.WrapPanel.OrientationProperty
 
     /// <summary>
@@ -296,6 +392,54 @@ public static partial class WrapPanelExtensions
     public static T OnOrientation<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<Avalonia.Layout.Orientation>> handler) where T : Avalonia.Controls.WrapPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.WrapPanel.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WrapPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Layout.Orientation>> ObserveBindingOrientation(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WrapPanel.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WrapPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingOrientation<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<BindingValue<Avalonia.Layout.Orientation>>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WrapPanel.OrientationProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WrapPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveOrientationChanged(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.OrientationProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WrapPanel.OrientationProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnOrientationChanged<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.OrientationProperty);
         handler(obj, observable);
         return obj;
     }
@@ -418,6 +562,54 @@ public static partial class WrapPanelExtensions
     public static T OnItemsAlignment<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<Avalonia.Controls.WrapPanelItemsAlignment>> handler) where T : Avalonia.Controls.WrapPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.WrapPanel.ItemsAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<Avalonia.Controls.WrapPanelItemsAlignment>> ObserveBindingItemsAlignment(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemsAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemsAlignment<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<BindingValue<Avalonia.Controls.WrapPanelItemsAlignment>>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemsAlignmentProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemsAlignmentChanged(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemsAlignmentProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemsAlignmentProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemsAlignmentChanged<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemsAlignmentProperty);
         handler(obj, observable);
         return obj;
     }
@@ -556,6 +748,54 @@ public static partial class WrapPanelExtensions
         return obj;
     }
 
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingItemWidth(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemWidth<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemWidthChanged(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemWidthProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemWidthProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemWidthChanged<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemWidthProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
     // Avalonia.Controls.WrapPanel.ItemHeightProperty
 
     /// <summary>
@@ -650,6 +890,54 @@ public static partial class WrapPanelExtensions
     public static T OnItemHeight<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<System.Double>> handler) where T : Avalonia.Controls.WrapPanel
     {
         var observable = obj.GetObservable(Avalonia.Controls.WrapPanel.ItemHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable including binding errors.</returns>
+    public static IObservable<BindingValue<System.Double>> ObserveBindingItemHeight(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with a binding observable for <see cref="Avalonia.Controls.WrapPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and binding observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnBindingItemHeight<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<BindingValue<System.Double>>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetBindingObservable(Avalonia.Controls.WrapPanel.ItemHeightProperty);
+        handler(obj, observable);
+        return obj;
+    }
+
+    /// <summary>
+    /// Gets a property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <returns>An observable with property change details.</returns>
+    public static IObservable<AvaloniaPropertyChangedEventArgs> ObserveItemHeightChanged(this Avalonia.Controls.WrapPanel obj)
+    {
+        return obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets a handler with property change observable for <see cref="Avalonia.Controls.WrapPanel.ItemHeightProperty"/>.
+    /// </summary>
+    /// <param name="obj">The target object.</param>
+    /// <param name="handler">The handler with target object and property change observable.</param>
+    /// <typeparam name="T">The type of the target object.</typeparam>
+    /// <returns>The target object reference.</returns>
+    public static T OnItemHeightChanged<T>(this T obj, Action<Avalonia.Controls.WrapPanel, IObservable<AvaloniaPropertyChangedEventArgs>> handler) where T : Avalonia.Controls.WrapPanel
+    {
+        var observable = obj.GetPropertyChangedObservable(Avalonia.Controls.WrapPanel.ItemHeightProperty);
         handler(obj, observable);
         return obj;
     }


### PR DESCRIPTION
## Summary
- run code generation without initializing UI platform
- add binding error and property change helpers to generated extensions
- provide runtime reactive helpers for UI thread dispatching and disposables
- revert generated files and rely on generator
- restore AppBuilder initialization for generator
- document extension helpers in README
- **expand README extension docs**

## Testing
- `dotnet build NXUI.sln -v:minimal`


------
https://chatgpt.com/codex/tasks/task_e_687672a2705c83219d5a1e4f9b689f9e